### PR TITLE
Fix for issue 154

### DIFF
--- a/src/main/java/net/nightwhistler/pageturner/activity/CatalogActivity.java
+++ b/src/main/java/net/nightwhistler/pageturner/activity/CatalogActivity.java
@@ -710,7 +710,11 @@ public class CatalogActivity extends RoboActivity implements OnItemClickListener
 				}
 				
 				Link searchLink = feed.findByRel(AtomConstants.REL_SEARCH);
-				
+
+				URL mBaseUrl = new URL(baseUrl);
+				URL mSearchUrl = new URL(mBaseUrl, searchLink.getHref());
+				searchLink.setHref(mSearchUrl.toString());
+
 				if ( searchLink != null && 
 						AtomConstants.TYPE_OPENSEARCH.equals(searchLink.getType())) {
 					HttpGet searchGet = new HttpGet( searchLink.getHref() );


### PR DESCRIPTION
search url inherits protocol, host name, and port number from baseUrl if not specified
