### PR TITLE
Remember "Scan for Books" dialog settings

### DIFF
--- a/res/layout/import_dialog.xml
+++ b/res/layout/import_dialog.xml
@@ -42,7 +42,6 @@
             android:layout_width="0dip"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="@string/ebook_path"
             android:inputType="textUri" />
 
         <Button

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -366,7 +366,6 @@
     <string name="zero_percent" translatable="false">0%  </string>
     <string name="default_timestamp" translatable="false">01-01-2012 13:44</string>
     <string name="default_device_name_and_progress" translatable="false">Phone - 15%</string>
-    <string name="ebook_path" translatable="false">/sdcard/eBooks</string>
     <string name="folder_name" translatable="false">Folder Name</string>
     <string name="small_text" translatable="false">Small Text</string>
     <string name="large_text" translatable="false">Large Text</string>

--- a/src/net/nightwhistler/pageturner/Configuration.java
+++ b/src/net/nightwhistler/pageturner/Configuration.java
@@ -193,6 +193,9 @@ public class Configuration {
 
     public static final String KEY_ALWAYS_OPEN_LAST_BOOK = "always_open_last_book";
 
+    public static final String KEY_SCAN_FOLDER = "scan_folder";
+    public static final String KEY_USE_SCAN_FOLDER = "use_scan_folder";
+    
 	// Flag for whether PageTurner is running on a Nook Simple Touch - an e-ink
 	// based Android device
 	
@@ -552,10 +555,6 @@ public class Configuration {
 		return settings.getBoolean(KEY_FULL_SCREEN, false);
 	}
 
-	public boolean isCopyToLibrayEnabled() {
-		return settings.getBoolean(KEY_COPY_TO_LIB, true);
-	}
-
 	public boolean isStripWhiteSpaceEnabled() {
 		return settings.getBoolean(KEY_STRIP_WHITESPACE, false);
 	}
@@ -871,6 +870,57 @@ public class Configuration {
 						ContextCompat.getExternalCacheDirs( context )
 				)
 		);
+    }
+
+    public boolean getCopyToLibraryOnScan() {
+	return settings.getBoolean(KEY_COPY_TO_LIB, true);
+    }
+
+    public void setCopyToLibraryOnScan(boolean value) {
+	settings.edit()
+	    .putBoolean(KEY_COPY_TO_LIB, value)
+	    .commit();
+    }
+
+    public boolean getUseCustomScanFolder() {
+	return settings.getBoolean(KEY_USE_SCAN_FOLDER, false);
+    }
+
+    public void setUseCustomScanFolder(boolean value) {
+	settings.edit()
+	    .putBoolean(KEY_USE_SCAN_FOLDER, value)
+	    .commit();
+    }
+
+    /** Return the default folder path which is shown for the "scan for books" custom directory
+     */
+    private String getDefaultScanFolder() {
+	return Configuration.IS_NOOK_TOUCH ?
+	    "/media" : /* Nook's default internal content storage (accessible via USB) is under /media */
+	    getStorageBase().unsafeGet().getAbsolutePath() + "/eBooks";
+    }
+
+    /** Return the folder path to show for the "scan for books" custom directory
+     */
+    public String getScanFolder() {
+	return settings.getString(KEY_SCAN_FOLDER, getDefaultScanFolder());
+    }
+
+    /** Set the folder path to show for "scan for books" custom directory.
+	Will only save a setting if the default actually changed.
+    */
+    public void setScanFolder(String value) {
+	SharedPreferences.Editor editor = settings.edit();
+
+	if(value == null || value.equals(getDefaultScanFolder())) {
+	    if(!settings.contains(KEY_SCAN_FOLDER))
+		return;
+	    editor.remove(KEY_SCAN_FOLDER);
+	} else if(new File(value).isDirectory()) {
+	    editor.putString(KEY_SCAN_FOLDER, value);
+	}
+
+	editor.commit();
     }
 
 	/**

--- a/src/net/nightwhistler/pageturner/catalog/DownloadFileTask.java
+++ b/src/net/nightwhistler/pageturner/catalog/DownloadFileTask.java
@@ -177,7 +177,7 @@ public class DownloadFileTask extends QueueableAsyncTask<String, Long, Void> {
                 if ( ! isCancelled() ) {
 				    //FIXME: This doesn't belong here really...
 				    Book book = new EpubReader().readEpubLazy( destFile.getAbsolutePath(), "UTF-8" );
-				    libraryService.storeBook(destFile.getAbsolutePath(), book, false, config.isCopyToLibrayEnabled() );
+				    libraryService.storeBook(destFile.getAbsolutePath(), book, false, config.getCopyToLibraryOnScan() );
                 }
 				
 			} else {

--- a/src/net/nightwhistler/pageturner/fragment/ReadingFragment.java
+++ b/src/net/nightwhistler/pageturner/fragment/ReadingFragment.java
@@ -1187,7 +1187,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
         backgroundHandler.post( () -> {
             try {
                 libraryService.storeBook(fileName, book, true,
-                        config.isCopyToLibrayEnabled());
+                        config.getCopyToLibraryOnScan());
             } catch (Exception io) {
                 LOG.error("Copy to library failed.", io);
             }


### PR DESCRIPTION
Hi Alex,

Thanks again for all your work on PageTurner. I really appreciate the UI improvements that have come over the last year or so, I find the UI very convenient now (I still regularly use PageTurner on my Nook Touch & on my Nexus 4).

This is a small PR for a minor usability thing, to remember the choices in the scan dialog so you don't have to re-type them each time. I think many people probably regularly important from the same place, I know I do, so it seemed useful to record those settings. Original commit message follows.

Let me know if you need me to make any adjustments to this.

Cheers,

Angus

***

When scanning, the choices you made in the dialog are saved for next
time.

Defaults are the same, except for Nook Touch which now defaults to
"/media" for the custom scan path (this is the internal storage, made
available via USB, etc.)

The "Copy to Library" option is now updated when you scan, or when you
change it in the Preferences (changing in the preferences may be
necessary if you only download or Open books rather than scanning for
them).