### PR TITLE
Standardise indentation, closes #573, add style note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Since PageTurner is dual-licensed, we can only accept contributions under the Ap
 
 Unless specifically stated to be otherwise, all contributions will be assumed to be licensed under the Apache 2.0 license.
 
+Code Style
+----------
+
+Relatively standard Java style:
+* Use 4 spaces for indenting, no tabs.
+* Opening braces at end of line not on new line.
+
+
 Building PageTurner
 -------------------
 

--- a/src/com/hlidskialf/android/preference/SeekBarPreference.java
+++ b/src/com/hlidskialf/android/preference/SeekBarPreference.java
@@ -1,6 +1,6 @@
-/* The following code was written by Matthew Wiggins 
- * and is released under the APACHE 2.0 license 
- * 
+/* The following code was written by Matthew Wiggins
+ * and is released under the APACHE 2.0 license
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hlidskialf.android.preference;
@@ -17,91 +17,90 @@ import android.widget.TextView;
 
 public class SeekBarPreference extends DialogPreference implements SeekBar.OnSeekBarChangeListener
 {
-	private static final String androidns="http://schemas.android.com/apk/res/android";
+    private static final String androidns="http://schemas.android.com/apk/res/android";
 
-	private SeekBar mSeekBar;
-	private TextView mSplashText,mValueText;
-	private Context mContext;
+    private SeekBar mSeekBar;
+    private TextView mSplashText,mValueText;
+    private Context mContext;
 
-	private String mDialogMessage, mSuffix;
-	private int mDefault, mMax, mValue = 0;
+    private String mDialogMessage, mSuffix;
+    private int mDefault, mMax, mValue = 0;
 
-	public SeekBarPreference(Context context, AttributeSet attrs) { 
-		super(context,attrs); 
-		mContext = context;
+    public SeekBarPreference(Context context, AttributeSet attrs) {
+        super(context,attrs);
+        mContext = context;
 
-		mDialogMessage = attrs.getAttributeValue(androidns,"dialogMessage");
-		mSuffix = attrs.getAttributeValue(androidns,"text");
-		mDefault = attrs.getAttributeIntValue(androidns,"defaultValue", 0);
-		mMax = attrs.getAttributeIntValue(androidns,"max", 100);
+        mDialogMessage = attrs.getAttributeValue(androidns,"dialogMessage");
+        mSuffix = attrs.getAttributeValue(androidns,"text");
+        mDefault = attrs.getAttributeIntValue(androidns,"defaultValue", 0);
+        mMax = attrs.getAttributeIntValue(androidns,"max", 100);
 
-	}
-	@Override 
-	protected View onCreateDialogView() {
-		LinearLayout.LayoutParams params;
-		LinearLayout layout = new LinearLayout(mContext);
-		layout.setOrientation(LinearLayout.VERTICAL);
-		layout.setPadding(6,6,6,6);
+    }
+    @Override
+    protected View onCreateDialogView() {
+        LinearLayout.LayoutParams params;
+        LinearLayout layout = new LinearLayout(mContext);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        layout.setPadding(6,6,6,6);
 
-		mSplashText = new TextView(mContext);
-		if (mDialogMessage != null)
-			mSplashText.setText(mDialogMessage);
-		layout.addView(mSplashText);
+        mSplashText = new TextView(mContext);
+        if (mDialogMessage != null)
+            mSplashText.setText(mDialogMessage);
+        layout.addView(mSplashText);
 
-		mValueText = new TextView(mContext);
-		mValueText.setGravity(Gravity.CENTER_HORIZONTAL);
-		mValueText.setTextSize(32);
-		params = new LinearLayout.LayoutParams(
-				LinearLayout.LayoutParams.FILL_PARENT, 
-				LinearLayout.LayoutParams.WRAP_CONTENT);
-		layout.addView(mValueText, params);
+        mValueText = new TextView(mContext);
+        mValueText.setGravity(Gravity.CENTER_HORIZONTAL);
+        mValueText.setTextSize(32);
+        params = new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.FILL_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT);
+        layout.addView(mValueText, params);
 
-		mSeekBar = new SeekBar(mContext);
-		mSeekBar.setOnSeekBarChangeListener(this);
-		layout.addView(mSeekBar, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.FILL_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+        mSeekBar = new SeekBar(mContext);
+        mSeekBar.setOnSeekBarChangeListener(this);
+        layout.addView(mSeekBar, new LinearLayout.LayoutParams(LinearLayout.LayoutParams.FILL_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT));
 
-		if (shouldPersist())
-			mValue = getPersistedInt(mDefault);
+        if (shouldPersist())
+            mValue = getPersistedInt(mDefault);
 
-		mSeekBar.setMax(mMax);
-		mSeekBar.setProgress(mValue);
-		return layout;
-	}
-	@Override 
-	protected void onBindDialogView(View v) {
-		super.onBindDialogView(v);
-		mSeekBar.setMax(mMax);		
-		mSeekBar.setProgress(mValue);
-	}
-	@Override
-	protected void onSetInitialValue(boolean restore, Object defaultValue)  
-	{
-		super.onSetInitialValue(restore, defaultValue);
-		if (restore) 
-			mValue = shouldPersist() ? getPersistedInt(mDefault) : 0;
-			else 
-				mValue = (Integer)defaultValue;
-	}
+        mSeekBar.setMax(mMax);
+        mSeekBar.setProgress(mValue);
+        return layout;
+    }
+    @Override
+    protected void onBindDialogView(View v) {
+        super.onBindDialogView(v);
+        mSeekBar.setMax(mMax);
+        mSeekBar.setProgress(mValue);
+    }
+    @Override
+    protected void onSetInitialValue(boolean restore, Object defaultValue)
+    {
+        super.onSetInitialValue(restore, defaultValue);
+        if (restore)
+            mValue = shouldPersist() ? getPersistedInt(mDefault) : 0;
+        else
+            mValue = (Integer)defaultValue;
+    }
 
-	public void onProgressChanged(SeekBar seek, int value, boolean fromTouch)
-	{
-		String t = String.valueOf(value);
-		mValueText.setText(mSuffix == null ? t : t.concat(mSuffix));
-		if (shouldPersist())
-			persistInt(value);
-		callChangeListener(Integer.valueOf(value));
-	}
-	public void onStartTrackingTouch(SeekBar seek) {}
-	public void onStopTrackingTouch(SeekBar seek) {}
+    public void onProgressChanged(SeekBar seek, int value, boolean fromTouch)
+    {
+        String t = String.valueOf(value);
+        mValueText.setText(mSuffix == null ? t : t.concat(mSuffix));
+        if (shouldPersist())
+            persistInt(value);
+        callChangeListener(Integer.valueOf(value));
+    }
+    public void onStartTrackingTouch(SeekBar seek) {}
+    public void onStopTrackingTouch(SeekBar seek) {}
 
-	public void setMax(int max) { mMax = max; }
-	public int getMax() { return mMax; }
+    public void setMax(int max) { mMax = max; }
+    public int getMax() { return mMax; }
 
-	public void setProgress(int progress) { 
-		mValue = progress;
-		if (mSeekBar != null)
-			mSeekBar.setProgress(progress); 
-	}
-	public int getProgress() { return mValue; }
+    public void setProgress(int progress) {
+        mValue = progress;
+        if (mSeekBar != null)
+            mSeekBar.setProgress(progress);
+    }
+    public int getProgress() { return mValue; }
 }
-

--- a/src/com/limecreativelabs/sherlocksupport/ActionBarDrawerToggleCompat.java
+++ b/src/com/limecreativelabs/sherlocksupport/ActionBarDrawerToggleCompat.java
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-package com.limecreativelabs.sherlocksupport;/*
+package com.limecreativelabs.sherlocksupport;
+/*
  * Copyright (C) 2010 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,7 +69,7 @@ public class ActionBarDrawerToggleCompat implements DrawerLayout.DrawerListener 
         Drawable getThemeUpIndicator(Activity activity);
 
         Object setActionBarUpIndicator(Object info, Activity activity,
-                                       Drawable themeImage, int contentDescRes);
+                Drawable themeImage, int contentDescRes);
 
         Object setActionBarDescription(Object info, Activity activity, int contentDescRes);
     }
@@ -81,7 +82,7 @@ public class ActionBarDrawerToggleCompat implements DrawerLayout.DrawerListener 
 
         @Override
         public Object setActionBarUpIndicator(Object info, Activity activity,
-                                              Drawable themeImage, int contentDescRes) {
+                Drawable themeImage, int contentDescRes) {
             // No action bar to set.
             return info;
         }
@@ -101,7 +102,7 @@ public class ActionBarDrawerToggleCompat implements DrawerLayout.DrawerListener 
 
         @Override
         public Object setActionBarUpIndicator(Object info, Activity activity,
-                                              Drawable themeImage, int contentDescRes) {
+                Drawable themeImage, int contentDescRes) {
             return ActionBarDrawerToggleSherlock.setActionBarUpIndicator(info, activity,
                     themeImage, contentDescRes);
         }
@@ -151,7 +152,7 @@ public class ActionBarDrawerToggleCompat implements DrawerLayout.DrawerListener 
      *                                  for accessibility
      */
     public ActionBarDrawerToggleCompat(Activity activity, DrawerLayout drawerLayout,
-                                       int drawerImageRes, int openDrawerContentDescRes, int closeDrawerContentDescRes) {
+            int drawerImageRes, int openDrawerContentDescRes, int closeDrawerContentDescRes) {
         mActivity = activity;
         mDrawerLayout = drawerLayout;
         mDrawerImageResource = drawerImageRes;

--- a/src/com/limecreativelabs/sherlocksupport/ActionBarDrawerToggleSherlock.java
+++ b/src/com/limecreativelabs/sherlocksupport/ActionBarDrawerToggleSherlock.java
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-package com.limecreativelabs.sherlocksupport;/*
+package com.limecreativelabs.sherlocksupport;
+/*
  * Copyright (C) 2010 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -54,12 +55,12 @@ class ActionBarDrawerToggleSherlock {
     private static final String TAG = "ActionBarDrawerToggleHoneycomb";
 
     private static final int[] THEME_ATTRS = new int[]{
-            android.R.attr.homeAsUpIndicator,
-            R.attr.homeAsUpIndicator
+        android.R.attr.homeAsUpIndicator,
+        R.attr.homeAsUpIndicator
     };
 
     public static Object setActionBarUpIndicator(Object info, Activity activity,
-                                                 Drawable drawable, int contentDescRes) {
+        Drawable drawable, int contentDescRes) {
         if (info == null) {
             info = new SetIndicatorInfo(activity);
         }
@@ -73,7 +74,7 @@ class ActionBarDrawerToggleSherlock {
     }
 
     public static Object setActionBarDescription(Object info, Activity activity,
-                                                 int contentDescRes) {
+        int contentDescRes) {
         if (info == null) {
             info = new SetIndicatorInfo(activity);
         }
@@ -112,9 +113,9 @@ class ActionBarDrawerToggleSherlock {
         SetIndicatorInfo(Activity activity) {
             try {
                 setHomeAsUpIndicator = ActionBar.class.getDeclaredMethod("setHomeAsUpIndicator",
-                        Drawable.class);
+                    Drawable.class);
                 setHomeActionContentDescription = ActionBar.class.getDeclaredMethod(
-                        "setHomeActionContentDescription", Integer.TYPE);
+                    "setHomeActionContentDescription", Integer.TYPE);
 
                 // If we got the method we won't need the stuff below.
                 return;

--- a/src/net/nightwhistler/nucular/atom/AtomConstants.java
+++ b/src/net/nightwhistler/nucular/atom/AtomConstants.java
@@ -19,31 +19,31 @@
 package net.nightwhistler.nucular.atom;
 
 public final class AtomConstants {
-	
-	public static final String TYPE_ATOM = "application/atom+xml";
-	public static final String TYPE_EPUB = "application/epub+zip";
-	
-	public static final String TYPE_OPENSEARCH = "application/opensearchdescription+xml";
 
-	public static final String REL_THUMBNAIL = "http://opds-spec.org/image/thumbnail";
-	public static final String REL_THUMBNAIL_ALT = "http://opds-spec.org/thumbnail";
-	
-	public static final String REL_STANZA_COVER_IMAGE = "x-stanza-cover-image";
-	public static final String REL_STANZA_THUMBNAIL_IMAGE = "x-stanza-cover-image-thumbnail";
-	public static final String REL_STANZA_BUY = "bookinfo";
-	
-	public static final String REL_BUY = "http://opds-spec.org/acquisition/buy";	
-	public static final String REL_IMAGE = "http://opds-spec.org/image";
-	public static final String REL_COVER = "http://opds-spec.org/cover";
-	
-	public static final String REL_ALTERNATE = "alternate";
+    public static final String TYPE_ATOM = "application/atom+xml";
+    public static final String TYPE_EPUB = "application/epub+zip";
+
+    public static final String TYPE_OPENSEARCH = "application/opensearchdescription+xml";
+
+    public static final String REL_THUMBNAIL = "http://opds-spec.org/image/thumbnail";
+    public static final String REL_THUMBNAIL_ALT = "http://opds-spec.org/thumbnail";
+
+    public static final String REL_STANZA_COVER_IMAGE = "x-stanza-cover-image";
+    public static final String REL_STANZA_THUMBNAIL_IMAGE = "x-stanza-cover-image-thumbnail";
+    public static final String REL_STANZA_BUY = "bookinfo";
+
+    public static final String REL_BUY = "http://opds-spec.org/acquisition/buy";
+    public static final String REL_IMAGE = "http://opds-spec.org/image";
+    public static final String REL_COVER = "http://opds-spec.org/cover";
+
+    public static final String REL_ALTERNATE = "alternate";
     public static final String REL_RELATED = "related";
     public static final String REL_WEBSITE = "website";
-	
 
-	public static final String REL_NEXT = "next";
-	public static final String REL_SEARCH = "search";
-	public static final String REL_PREV = "previous";
+
+    public static final String REL_NEXT = "next";
+    public static final String REL_SEARCH = "search";
+    public static final String REL_PREV = "previous";
 
     public static final String SEARCH_TERMS = "{searchTerms}";
 

--- a/src/net/nightwhistler/nucular/atom/AtomElement.java
+++ b/src/net/nightwhistler/nucular/atom/AtomElement.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -30,56 +30,56 @@ import static jedi.option.Options.some;
 
 public abstract class AtomElement implements Serializable {
 
-	private String title;
-	private String id;
-	private Content content;
-	
-	private Author author;
-	
-	private List<Link> links = new ArrayList<Link>();
+    private String title;
+    private String id;
+    private Content content;
 
-	public String getTitle() {
-		return title;
-	}
+    private Author author;
 
-	public void setTitle(String title) {
-		this.title = title;
-	}
+    private List<Link> links = new ArrayList<Link>();
 
-	public String getId() {
-		return id;
-	}
+    public String getTitle() {
+        return title;
+    }
 
-	public void setId(String id) {
-		this.id = id;
-	}
+    public void setTitle(String title) {
+        this.title = title;
+    }
 
-	public Content getContent() {
-		return content;
-	}
+    public String getId() {
+        return id;
+    }
 
-	public void setContent(Content content) {
-		this.content = content;
-	}
+    public void setId(String id) {
+        this.id = id;
+    }
 
-	public Author getAuthor() {
-		return author;
-	}
+    public Content getContent() {
+        return content;
+    }
 
-	public void setAuthor(Author author) {
-		this.author = author;
-	}
+    public void setContent(Content content) {
+        this.content = content;
+    }
 
-	public List<Link> getLinks() {
-		return Collections.unmodifiableList( links );
-	}		
-	
-	public void addLink( Link link ) {
-		this.links.add(link);
-	}	
-	
-	public Option<Link> findByRel(String rel) {
+    public Author getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(Author author) {
+        this.author = author;
+    }
+
+    public List<Link> getLinks() {
+        return Collections.unmodifiableList( links );
+    }
+
+    public void addLink( Link link ) {
+        this.links.add(link);
+    }
+
+    public Option<Link> findByRel(String rel) {
         return firstOption( getLinks(),
-                link -> link.getRel() != null && link.getRel().equals(rel) );
-	}
+            link -> link.getRel() != null && link.getRel().equals(rel) );
+    }
 }

--- a/src/net/nightwhistler/nucular/atom/Author.java
+++ b/src/net/nightwhistler/nucular/atom/Author.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -22,34 +22,34 @@ import java.io.Serializable;
 
 public class Author implements Serializable {
 
-	private String name;
-	private String email;
-	
-	private String uri;
+    private String name;
+    private String email;
 
-	public String getName() {
-		return name;
-	}
+    private String uri;
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public String getEmail() {
-		return email;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public void setEmail(String email) {
-		this.email = email;
-	}
+    public String getEmail() {
+        return email;
+    }
 
-	public String getUri() {
-		return uri;
-	}
+    public void setEmail(String email) {
+        this.email = email;
+    }
 
-	public void setUri(String uri) {
-		this.uri = uri;
-	}
-	
-	
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+
 }

--- a/src/net/nightwhistler/nucular/atom/Content.java
+++ b/src/net/nightwhistler/nucular/atom/Content.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -22,23 +22,23 @@ import java.io.Serializable;
 
 public class Content implements Serializable {
 
-	private String type;
-	private String text;
-	
-	public String getText() {
-		return text;
-	}
-	
-	public String getType() {
-		return type;
-	}
-	
-	public void setText(String text) {
-		this.text = text;
-	}
-	
-	public void setType(String type) {
-		this.type = type;
-	}
-	
+    private String type;
+    private String text;
+
+    public String getText() {
+        return text;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
 }

--- a/src/net/nightwhistler/nucular/atom/Entry.java
+++ b/src/net/nightwhistler/nucular/atom/Entry.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -32,16 +32,16 @@ import static net.nightwhistler.nucular.atom.AtomConstants.*;
 
 public class Entry extends AtomElement {
 
-	private String updated;
-	private String summary;
+    private String updated;
+    private String summary;
 
     private Feed feed;
 
     private String baseURL;
 
-	public String getUpdated() {
-		return updated;
-	}
+    public String getUpdated() {
+        return updated;
+    }
 
     public String getBaseURL() {
         return baseURL;
@@ -51,9 +51,9 @@ public class Entry extends AtomElement {
         this.baseURL = baseURL;
     }
 
-	public void setUpdated(String updated) {
-		this.updated = updated;
-	}
+    public void setUpdated(String updated) {
+        this.updated = updated;
+    }
 
     public void setFeed(Feed feed) {
         this.feed = feed;
@@ -67,35 +67,35 @@ public class Entry extends AtomElement {
         return findByRel(AtomConstants.REL_WEBSITE);
     }
 
-	public Option<Link> getAlternateLink() {
-		Option<Link> atomLink = getAtomLink();
+    public Option<Link> getAlternateLink() {
+        Option<Link> atomLink = getAtomLink();
 
         return atomLink.filter(l -> l.getRel() != null && l.getRel().equalsIgnoreCase(REL_ALTERNATE));
-	}
-	
-	public Option<Link> getAtomLink() {
-		List<Link> links = getLinks();
+    }
+
+    public Option<Link> getAtomLink() {
+        List<Link> links = getLinks();
 
         return firstOption( links, l -> l.getType().startsWith(TYPE_ATOM));
-	}
-	
-	public String getSummary() {
-		return summary;
-	}
-	
-	public void setSummary(String summary) {
-		this.summary = summary;
-	}
-	
-	private Option<Link> findByRel(String... items) {
-		Option<Link> link = none();
+    }
 
-		for ( int i=0; i < items.length && isEmpty(link); i++ ) {
-			link = findByRel( items[i] );
-		}
-		
-		return link;
-	}
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    private Option<Link> findByRel(String... items) {
+        Option<Link> link = none();
+
+        for ( int i=0; i < items.length && isEmpty(link); i++ ) {
+            link = findByRel( items[i] );
+        }
+
+        return link;
+    }
 
     public List<Link> getAlternateLinks() {
 
@@ -115,19 +115,19 @@ public class Entry extends AtomElement {
 
     }
 
-	public Option<Link> getThumbnailLink() {
-		return findByRel(REL_THUMBNAIL, REL_THUMBNAIL_ALT, REL_STANZA_THUMBNAIL_IMAGE);
-	}
-	
-	public Option<Link> getImageLink() {
-		return findByRel(REL_IMAGE, REL_COVER, REL_STANZA_COVER_IMAGE );		
-	}
-	
-	public Option<Link> getBuyLink() {
-		return findByRel(REL_BUY, REL_STANZA_BUY);
-	}
-	
-	public Option<Link> getEpubLink() {
+    public Option<Link> getThumbnailLink() {
+        return findByRel(REL_THUMBNAIL, REL_THUMBNAIL_ALT, REL_STANZA_THUMBNAIL_IMAGE);
+    }
+
+    public Option<Link> getImageLink() {
+        return findByRel(REL_IMAGE, REL_COVER, REL_STANZA_COVER_IMAGE );
+    }
+
+    public Option<Link> getBuyLink() {
+        return findByRel(REL_BUY, REL_STANZA_BUY);
+    }
+
+    public Option<Link> getEpubLink() {
         return firstOption( getLinks(), link -> link.getType() != null && link.getType().equals(TYPE_EPUB));
-	}
+    }
 }

--- a/src/net/nightwhistler/nucular/atom/Feed.java
+++ b/src/net/nightwhistler/nucular/atom/Feed.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -28,39 +28,39 @@ import static net.nightwhistler.nucular.atom.AtomConstants.*;
 
 /**
  * Represents a low-level Atom feed, as parsed from XML.
- * 
+ *
  * @author Alex Kuiper
  *
  */
-public class Feed extends AtomElement {	
-	
-	private boolean detailFeed;
+public class Feed extends AtomElement {
+
+    private boolean detailFeed;
     private boolean searchFeed;
 
     private String url;
 
-	private List<Entry> entries = new ArrayList<Entry>();
-	
-	public List<Entry> getEntries() {
-		return Collections.unmodifiableList( entries );
-	}
+    private List<Entry> entries = new ArrayList<Entry>();
+
+    public List<Entry> getEntries() {
+        return Collections.unmodifiableList( entries );
+    }
 
     public void addEntryAt(int position, Entry entry) {
         this.entries.add(position, entry);
     }
-	
-	public void addEntry(Entry entry) {
-		this.entries.add(entry);
+
+    public void addEntry(Entry entry) {
+        this.entries.add(entry);
         entry.setFeed(this);
-	}
+    }
 
     public void removeEntry(Entry entry) {
         this.entries.remove(entry);
     }
-	
-	public Option<Link> getNextLink() {
-		return findByRel(REL_NEXT);
-	}
+
+    public Option<Link> getNextLink() {
+        return findByRel(REL_NEXT);
+    }
 
     public void setURL(String url) {
         this.url = url;
@@ -69,34 +69,34 @@ public class Feed extends AtomElement {
     public String getURL() {
         return this.url;
     }
-	
-	public Option<Link> getPreviousLink() {
-		return findByRel(REL_PREV);
-	}
-	
-	public Option<Link> getSearchLink() {
-		Option<Link> link = findByRel(REL_SEARCH);
+
+    public Option<Link> getPreviousLink() {
+        return findByRel(REL_PREV);
+    }
+
+    public Option<Link> getSearchLink() {
+        Option<Link> link = findByRel(REL_SEARCH);
 
         return link.filter( l -> l.getType().equals(AtomConstants.TYPE_ATOM ));
-	}
-	
-	public void setDetailFeed(boolean detailFeed) {
-		this.detailFeed = detailFeed;
-	}
+    }
+
+    public void setDetailFeed(boolean detailFeed) {
+        this.detailFeed = detailFeed;
+    }
 
     public void setSearchFeed(boolean searchFeed) {
         this.searchFeed = searchFeed;
     }
-	
-	public boolean isDetailFeed() {
-		return detailFeed;
-	}
+
+    public boolean isDetailFeed() {
+        return detailFeed;
+    }
 
     public boolean isSearchFeed() {
         return searchFeed;
     }
-	
-	public int getSize() {
-		return getEntries().size();
-	}
+
+    public int getSize() {
+        return getEntries().size();
+    }
 }

--- a/src/net/nightwhistler/nucular/atom/Link.java
+++ b/src/net/nightwhistler/nucular/atom/Link.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -18,42 +18,41 @@
  */
 package net.nightwhistler.nucular.atom;
 
-
 import java.io.Serializable;
 
 public class Link implements Serializable {
 
-	private String href;
-	private String type;
-	private String rel;
+    private String href;
+    private String type;
+    private String rel;
     private String title;
-	
-	public Link( String href, String type, String rel, String title ) {
-		this.href = href;
-		this.type = type;
-		this.rel = rel;
-        this.title = title;
-	}
 
-	public String getHref() {
-		return href;
-	}
-	public void setHref(String href) {
-		this.href = href;		
-	}
-	public String getType() {
-		return type;
-	}
-	public void setType(String type) {
-		this.type = type;
-	}
-	
-	public String getRel() {
-		return rel;
-	}
-	public void setRel(String rel) {
-		this.rel = rel;
-	}
+    public Link( String href, String type, String rel, String title ) {
+        this.href = href;
+        this.type = type;
+        this.rel = rel;
+        this.title = title;
+    }
+
+    public String getHref() {
+        return href;
+    }
+    public void setHref(String href) {
+        this.href = href;
+    }
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getRel() {
+        return rel;
+    }
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
 
     public String getTitle() {
         return title;
@@ -62,5 +61,5 @@ public class Link implements Serializable {
     public void setTitle(String title) {
         this.title = title;
     }
-	
+
 }

--- a/src/net/nightwhistler/nucular/parser/AuthorParser.java
+++ b/src/net/nightwhistler/nucular/parser/AuthorParser.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -22,60 +22,60 @@ import net.nightwhistler.nucular.atom.AtomElement;
 import net.nightwhistler.nucular.atom.Author;
 
 public class AuthorParser extends ElementParser {
-	
-	private Author author;
 
-	public AuthorParser(AtomElement parent) {
-		super("author");
-		this.author = new Author();
-		parent.setAuthor(author);
-	}
-	
-	@Override
-	protected ElementParser createChildParser(String tagName) {
-		
-		if ( tagName.equals("name")) {
-			return new NameParser();
-		} else if ( tagName.equals("uri")) {
-			return new UriParser();
-		} else if ( tagName.equals("email")) {
-			return new EmailParser();
-		}
-		
-		return super.createChildParser(tagName);
-	}
-	
-	private class NameParser extends ElementParser {
-		public NameParser() {
-			super("name");
-		}
-		
-		@Override
-		public void setTextContent(String text) {
-			author.setName(text);
-		}
-	}
-	
-	private class UriParser extends ElementParser {
-		public UriParser() {
-			super("uri");
-		}
-		
-		@Override
-		public void setTextContent(String text) {
-			author.setUri(text);
-		}
-	}
-	
-	private class EmailParser extends ElementParser {
-		public EmailParser() {
-			super("email");
-		}
-		
-		@Override
-		public void setTextContent(String text) {
-			author.setEmail(text);
-		}
-	}
-	
+    private Author author;
+
+    public AuthorParser(AtomElement parent) {
+        super("author");
+        this.author = new Author();
+        parent.setAuthor(author);
+    }
+
+    @Override
+    protected ElementParser createChildParser(String tagName) {
+
+        if ( tagName.equals("name")) {
+            return new NameParser();
+        } else if ( tagName.equals("uri")) {
+            return new UriParser();
+        } else if ( tagName.equals("email")) {
+            return new EmailParser();
+        }
+
+        return super.createChildParser(tagName);
+    }
+
+    private class NameParser extends ElementParser {
+        public NameParser() {
+            super("name");
+        }
+
+        @Override
+        public void setTextContent(String text) {
+            author.setName(text);
+        }
+    }
+
+    private class UriParser extends ElementParser {
+        public UriParser() {
+            super("uri");
+        }
+
+        @Override
+        public void setTextContent(String text) {
+            author.setUri(text);
+        }
+    }
+
+    private class EmailParser extends ElementParser {
+        public EmailParser() {
+            super("email");
+        }
+
+        @Override
+        public void setTextContent(String text) {
+            author.setEmail(text);
+        }
+    }
+
 }

--- a/src/net/nightwhistler/nucular/parser/ContentParser.java
+++ b/src/net/nightwhistler/nucular/parser/ContentParser.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -24,51 +24,51 @@ import net.nightwhistler.nucular.atom.Content;
 import java.util.Map;
 
 public class ContentParser extends ElementParser {
-	
-	private Content content;
-	
-	StringBuffer buffer;
-	
-	private boolean finished;
-	
-	public ContentParser(AtomElement parent) {
-		super("content");
-		this.content = new Content();
-		parent.setContent(content);
-		
-		this.buffer = new StringBuffer();
-		this.finished = false;
-	}
-	
-	@Override
-	public void startElement(String name, Map<String, String> attributes) {
-		this.buffer.append("<" + name + ">");
-	}
-	
-	@Override
-	public boolean isFinished() {
-		return finished;
-	}
-	
-	@Override
-	public void setAttributes(Map<String, String> attributes) {
-		this.content.setType(attributes.get("type"));
-	}
-	
-	@Override
-	public void endElement(String name) {
-		
-		if ( name.equals("content") ) {
-			finished = true;
-			this.content.setText(buffer.toString());
-		} else {		
-			this.buffer.append( "</" + name + ">" );
-		}
-		
-	}
-	
-	@Override
-	public void setTextContent(String text) {
-		this.buffer.append( text );
-	}
+
+    private Content content;
+
+    StringBuffer buffer;
+
+    private boolean finished;
+
+    public ContentParser(AtomElement parent) {
+        super("content");
+        this.content = new Content();
+        parent.setContent(content);
+
+        this.buffer = new StringBuffer();
+        this.finished = false;
+    }
+
+    @Override
+    public void startElement(String name, Map<String, String> attributes) {
+        this.buffer.append("<" + name + ">");
+    }
+
+    @Override
+    public boolean isFinished() {
+        return finished;
+    }
+
+    @Override
+    public void setAttributes(Map<String, String> attributes) {
+        this.content.setType(attributes.get("type"));
+    }
+
+    @Override
+    public void endElement(String name) {
+
+        if ( name.equals("content") ) {
+            finished = true;
+            this.content.setText(buffer.toString());
+        } else {
+            this.buffer.append( "</" + name + ">" );
+        }
+
+    }
+
+    @Override
+    public void setTextContent(String text) {
+        this.buffer.append( text );
+    }
 }

--- a/src/net/nightwhistler/nucular/parser/ElementParser.java
+++ b/src/net/nightwhistler/nucular/parser/ElementParser.java
@@ -1,7 +1,7 @@
 
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -22,58 +22,58 @@ package net.nightwhistler.nucular.parser;
 import java.util.Map;
 
 public abstract class ElementParser {
-	
-	private String elementName;
-	
-	private ElementParser childParser;
-	
-	private boolean finished;
-	
-	public ElementParser(String elementName) {
-		this.elementName = elementName;
-		this.finished = false;
-	}
 
-	public void startElement( String name, Map<String, String> attributes ) {
-		
-		if ( this.childParser != null ) {
-			childParser.startElement(name, attributes);
-		} else {
-			this.childParser = createChildParser(name);		
-			this.childParser.setAttributes(attributes);
-		}
-	}
-	
-	public boolean isFinished() {
-		return finished;
-	}
-	
-	public void endElement( String name ) {
-		
-		if ( this.childParser != null ) {
-			this.childParser.endElement(name);
-			
-			if ( childParser.isFinished() ) {
-				childParser = null;
-			}
-		} else {
-			if ( name.equals(this.elementName) ) {
-				this.finished = true;
-			}
-		}
-		
-	}
-	
-	public void setTextContent( String text ) {
-		if ( childParser != null ) {
-			childParser.setTextContent(text);
-		}
-	}
-	
-	public void setAttributes( Map<String, String> attributes ) {}
+    private String elementName;
 
-	protected ElementParser createChildParser(String tagName) {
-		return new UnknownElementParser(tagName);
-	}
+    private ElementParser childParser;
+
+    private boolean finished;
+
+    public ElementParser(String elementName) {
+        this.elementName = elementName;
+        this.finished = false;
+    }
+
+    public void startElement( String name, Map<String, String> attributes ) {
+
+        if ( this.childParser != null ) {
+            childParser.startElement(name, attributes);
+        } else {
+            this.childParser = createChildParser(name);
+            this.childParser.setAttributes(attributes);
+        }
+    }
+
+    public boolean isFinished() {
+        return finished;
+    }
+
+    public void endElement( String name ) {
+
+        if ( this.childParser != null ) {
+            this.childParser.endElement(name);
+
+            if ( childParser.isFinished() ) {
+                childParser = null;
+            }
+        } else {
+            if ( name.equals(this.elementName) ) {
+                this.finished = true;
+            }
+        }
+
+    }
+
+    public void setTextContent( String text ) {
+        if ( childParser != null ) {
+            childParser.setTextContent(text);
+        }
+    }
+
+    public void setAttributes( Map<String, String> attributes ) {}
+
+    protected ElementParser createChildParser(String tagName) {
+        return new UnknownElementParser(tagName);
+    }
 
 }

--- a/src/net/nightwhistler/nucular/parser/EntryParser.java
+++ b/src/net/nightwhistler/nucular/parser/EntryParser.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -22,32 +22,32 @@ import net.nightwhistler.nucular.atom.Entry;
 import net.nightwhistler.nucular.atom.Feed;
 
 public class EntryParser extends ElementParser {
-				
-	private Entry entry;
-	
-	public EntryParser(Feed parent) {
-		super("entry");
-		this.entry = new Entry();
-		parent.addEntry(entry);
-	}	
 
-	@Override
-	protected ElementParser createChildParser(String tagName) {
-		
-		if ( tagName.equals("link")) {
-			return new LinkParser(entry);
-		} else if ( tagName.equals("content")) {
-			return new ContentParser(entry);
-		} else if ( tagName.equals("title") ) {
-			return new TitleParser(entry);
-		} else if ( tagName.equals("author")) {
-			return new AuthorParser(entry);
-		} else if ( tagName.equals("id")) {
-			return new IDParser(entry);
-		} else if ( tagName.equals("summary")) {
-			return new SummaryParser(entry);
-		}
-		
-		return super.createChildParser(tagName);
-	}
+    private Entry entry;
+
+    public EntryParser(Feed parent) {
+        super("entry");
+        this.entry = new Entry();
+        parent.addEntry(entry);
+    }
+
+    @Override
+    protected ElementParser createChildParser(String tagName) {
+
+        if ( tagName.equals("link")) {
+            return new LinkParser(entry);
+        } else if ( tagName.equals("content")) {
+            return new ContentParser(entry);
+        } else if ( tagName.equals("title") ) {
+            return new TitleParser(entry);
+        } else if ( tagName.equals("author")) {
+            return new AuthorParser(entry);
+        } else if ( tagName.equals("id")) {
+            return new IDParser(entry);
+        } else if ( tagName.equals("summary")) {
+            return new SummaryParser(entry);
+        }
+
+        return super.createChildParser(tagName);
+    }
 }

--- a/src/net/nightwhistler/nucular/parser/FeedParser.java
+++ b/src/net/nightwhistler/nucular/parser/FeedParser.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -24,43 +24,43 @@ import java.util.Map;
 
 
 public class FeedParser extends ElementParser {
-	
-	private Feed feed;
-	
-	public FeedParser() {
-		super("feed");
-		this.feed = new Feed();
-	}
-	
-	public Feed getFeed() {
-		return feed;
-	}
-	
-	@Override
-	public void startElement(String name, Map<String, String> attributes) {
-		if ( ! name.equals("feed") ) { //Minor bootstrapping hack
-			super.startElement(name, attributes);
-		}
-	}
-	
-	@Override
-	protected ElementParser createChildParser(String tagName) {
-		
-		if ( tagName.equals("link")) {
-			return new LinkParser(feed);
-		} else if ( tagName.equals("content")) {
-			return new ContentParser(feed);
-		} else if ( tagName.equals("title") ) {
-			return new TitleParser(feed);
-		} else if ( tagName.equals("entry")) {
-			return new EntryParser(feed);
-		} else if ( tagName.equals("author")) {
-			return new AuthorParser(feed);
-		} else if ( tagName.equals("id")) {
-			return new IDParser(feed);
-		}
-		
-		return super.createChildParser(tagName);
-	}
+
+    private Feed feed;
+
+    public FeedParser() {
+        super("feed");
+        this.feed = new Feed();
+    }
+
+    public Feed getFeed() {
+        return feed;
+    }
+
+    @Override
+    public void startElement(String name, Map<String, String> attributes) {
+        if ( ! name.equals("feed") ) { //Minor bootstrapping hack
+            super.startElement(name, attributes);
+        }
+    }
+
+    @Override
+    protected ElementParser createChildParser(String tagName) {
+
+        if ( tagName.equals("link")) {
+            return new LinkParser(feed);
+        } else if ( tagName.equals("content")) {
+            return new ContentParser(feed);
+        } else if ( tagName.equals("title") ) {
+            return new TitleParser(feed);
+        } else if ( tagName.equals("entry")) {
+            return new EntryParser(feed);
+        } else if ( tagName.equals("author")) {
+            return new AuthorParser(feed);
+        } else if ( tagName.equals("id")) {
+            return new IDParser(feed);
+        }
+
+        return super.createChildParser(tagName);
+    }
 
 }

--- a/src/net/nightwhistler/nucular/parser/IDParser.java
+++ b/src/net/nightwhistler/nucular/parser/IDParser.java
@@ -23,15 +23,15 @@ import net.nightwhistler.nucular.atom.AtomElement;
 
 public class IDParser extends ElementParser {
 
-	private AtomElement parent;
-	
-	public IDParser(AtomElement parent) {		
-		super("id");
-		this.parent = parent;
-	}
-	
-	@Override
-	public void setTextContent(String text) {
-		parent.setId(text);
-	}
+    private AtomElement parent;
+
+    public IDParser(AtomElement parent) {
+        super("id");
+        this.parent = parent;
+    }
+
+    @Override
+    public void setTextContent(String text) {
+        parent.setId(text);
+    }
 }

--- a/src/net/nightwhistler/nucular/parser/LinkParser.java
+++ b/src/net/nightwhistler/nucular/parser/LinkParser.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -25,22 +25,22 @@ import java.util.Map;
 
 public class LinkParser extends ElementParser {
 
-	private AtomElement element;
-	
-	public LinkParser(AtomElement parent) {
-		super("link");
-		this.element = parent;
-	}	
-	
-	@Override
-	public void setAttributes(Map<String, String> attributes) {
-		Link link = new Link(
-				attributes.get("href"),
-				attributes.get("type"),
-				attributes.get("rel"),
-                attributes.get("title"));
-		
-		this.element.addLink(link);
-	}
-	
+    private AtomElement element;
+
+    public LinkParser(AtomElement parent) {
+        super("link");
+        this.element = parent;
+    }
+
+    @Override
+    public void setAttributes(Map<String, String> attributes) {
+        Link link = new Link(
+            attributes.get("href"),
+            attributes.get("type"),
+            attributes.get("rel"),
+            attributes.get("title"));
+
+        this.element.addLink(link);
+    }
+
 }

--- a/src/net/nightwhistler/nucular/parser/Nucular.java
+++ b/src/net/nightwhistler/nucular/parser/Nucular.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -33,34 +33,34 @@ import java.io.InputStream;
 
 public class Nucular {
 
-	public static Feed readAtomFeedFromStream(InputStream stream)
-			throws ParserConfigurationException, SAXException, IOException {
+    public static Feed readAtomFeedFromStream(InputStream stream)
+        throws ParserConfigurationException, SAXException, IOException {
 
-		FeedParser feedParser = new FeedParser();		
-		parseStream(feedParser, stream );
-		return feedParser.getFeed();
-	}
-	
-	public static SearchDescription readOpenSearchFromStream(InputStream stream ) 
-			throws ParserConfigurationException, SAXException, IOException {
-		OpenSearchParser search = new OpenSearchParser();
-		parseStream(search, stream);
-		
-		return search.getDesc();
-	}
-	
-	private static void parseStream( ElementParser rootElementsParser, InputStream stream ) 
-			throws ParserConfigurationException, SAXException, IOException {
-		
-		SAXParserFactory parseFactory = SAXParserFactory.newInstance();
-		SAXParser xmlParser = parseFactory.newSAXParser();
+        FeedParser feedParser = new FeedParser();
+        parseStream(feedParser, stream );
+        return feedParser.getFeed();
+    }
 
-		XMLReader xmlIn = xmlParser.getXMLReader();
-		
-		StreamParser catalogParser = new StreamParser( rootElementsParser );
-		xmlIn.setContentHandler(catalogParser);
+    public static SearchDescription readOpenSearchFromStream(InputStream stream )
+        throws ParserConfigurationException, SAXException, IOException {
+        OpenSearchParser search = new OpenSearchParser();
+        parseStream(search, stream);
 
-		xmlIn.parse(new InputSource(stream));
-	}
+        return search.getDesc();
+    }
+
+    private static void parseStream( ElementParser rootElementsParser, InputStream stream )
+        throws ParserConfigurationException, SAXException, IOException {
+
+        SAXParserFactory parseFactory = SAXParserFactory.newInstance();
+        SAXParser xmlParser = parseFactory.newSAXParser();
+
+        XMLReader xmlIn = xmlParser.getXMLReader();
+
+        StreamParser catalogParser = new StreamParser( rootElementsParser );
+        xmlIn.setContentHandler(catalogParser);
+
+        xmlIn.parse(new InputSource(stream));
+    }
 
 }

--- a/src/net/nightwhistler/nucular/parser/StreamParser.java
+++ b/src/net/nightwhistler/nucular/parser/StreamParser.java
@@ -28,49 +28,49 @@ import java.util.Map;
 
 public class StreamParser extends DefaultHandler {
 
-	private ElementParser rootParser;
-	
-	public StreamParser( ElementParser rootElementParser ) {
-		this.rootParser = rootElementParser;
-	}
+    private ElementParser rootParser;
 
-	private String pickName( String qName, String localName ) {
-		if ( localName.length() == 0 ) {
-			return qName;
-		} else {
-			return localName;
-		}
-	}
-	
-	@Override
-	public void startElement(String uri, String localName, String qName,
-			Attributes attributes) throws SAXException {
+    public StreamParser( ElementParser rootElementParser ) {
+        this.rootParser = rootElementParser;
+    }
 
-		Map<String, String> attrMap = new HashMap<String, String>();
-		for (int i = 0; i < attributes.getLength(); i++) {
-			String value = attributes.getValue(i);
-			String key = attributes.getLocalName(i);
-			attrMap.put(key, value);
-		}
+    private String pickName( String qName, String localName ) {
+        if ( localName.length() == 0 ) {
+            return qName;
+        } else {
+            return localName;
+        }
+    }
 
-		this.rootParser.startElement(pickName(qName, localName), attrMap);
-	}
+    @Override
+    public void startElement(String uri, String localName, String qName,
+        Attributes attributes) throws SAXException {
 
-	@Override
-	public void characters(char[] ch, int start, int length)
-			throws SAXException {
+        Map<String, String> attrMap = new HashMap<String, String>();
+        for (int i = 0; i < attributes.getLength(); i++) {
+            String value = attributes.getValue(i);
+            String key = attributes.getLocalName(i);
+            attrMap.put(key, value);
+        }
 
-		StringBuffer buff = new StringBuffer();
-		buff.append(ch, start, length);
+        this.rootParser.startElement(pickName(qName, localName), attrMap);
+    }
 
-		this.rootParser.setTextContent(buff.toString());
-	}
+    @Override
+    public void characters(char[] ch, int start, int length)
+        throws SAXException {
 
-	@Override
-	public void endElement(String uri, String localName, String qName)
-			throws SAXException {
-		this.rootParser.endElement(pickName(qName,localName));
-	}
+        StringBuffer buff = new StringBuffer();
+        buff.append(ch, start, length);
 
-	
+        this.rootParser.setTextContent(buff.toString());
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName)
+        throws SAXException {
+        this.rootParser.endElement(pickName(qName,localName));
+    }
+
+
 }

--- a/src/net/nightwhistler/nucular/parser/SummaryParser.java
+++ b/src/net/nightwhistler/nucular/parser/SummaryParser.java
@@ -22,15 +22,15 @@ import net.nightwhistler.nucular.atom.Entry;
 
 public class SummaryParser extends ElementParser {
 
-	private Entry parent;
-	
-	public SummaryParser(Entry parent) {
-		super("summary");
-		this.parent = parent;
-	}
-	
-	@Override
-	public void setTextContent(String text) {
-		parent.setSummary(text);
-	}
+    private Entry parent;
+
+    public SummaryParser(Entry parent) {
+        super("summary");
+        this.parent = parent;
+    }
+
+    @Override
+    public void setTextContent(String text) {
+        parent.setSummary(text);
+    }
 }

--- a/src/net/nightwhistler/nucular/parser/TitleParser.java
+++ b/src/net/nightwhistler/nucular/parser/TitleParser.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -24,37 +24,37 @@ import java.util.Map;
 
 public class TitleParser extends ElementParser {
 
-	private AtomElement parent;
-	
-	private boolean finished = false;
-	StringBuffer buffer = new StringBuffer();
-	
-	public TitleParser(AtomElement parent) {
-		super("title");
-		this.parent = parent;
-	}
-	
-	@Override
-	public void startElement(String name, Map<String, String> attributes) {
-		//Do nothing
-	}
-	
-	@Override
-	public void endElement(String name) {
-		if ( name.equals("title") ) {
-			this.finished = true;
-			parent.setTitle(buffer.toString().trim());
-		}
-	}
-	
-	@Override
-	public boolean isFinished() {
-		return finished;
-	}
-	
-	@Override
-	public void setTextContent(String text) {
-		buffer.append(text);
-	}
-	
+    private AtomElement parent;
+
+    private boolean finished = false;
+    StringBuffer buffer = new StringBuffer();
+
+    public TitleParser(AtomElement parent) {
+        super("title");
+        this.parent = parent;
+    }
+
+    @Override
+    public void startElement(String name, Map<String, String> attributes) {
+        //Do nothing
+    }
+
+    @Override
+    public void endElement(String name) {
+        if ( name.equals("title") ) {
+            this.finished = true;
+            parent.setTitle(buffer.toString().trim());
+        }
+    }
+
+    @Override
+    public boolean isFinished() {
+        return finished;
+    }
+
+    @Override
+    public void setTextContent(String text) {
+        buffer.append(text);
+    }
+
 }

--- a/src/net/nightwhistler/nucular/parser/UnknownElementParser.java
+++ b/src/net/nightwhistler/nucular/parser/UnknownElementParser.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -20,8 +20,8 @@ package net.nightwhistler.nucular.parser;
 
 
 public class UnknownElementParser extends ElementParser {
-	
-	public UnknownElementParser(String name) {
-		super(name);	
-	}	
+
+    public UnknownElementParser(String name) {
+        super(name);
+    }
 }

--- a/src/net/nightwhistler/nucular/parser/opensearch/OpenSearchParser.java
+++ b/src/net/nightwhistler/nucular/parser/opensearch/OpenSearchParser.java
@@ -24,34 +24,34 @@ import net.nightwhistler.nucular.parser.ElementParser;
 import java.util.Map;
 
 public class OpenSearchParser extends ElementParser {
-	
-	private SearchDescription desc;
-	
-	public OpenSearchParser() {
-		super("OpenSearchDescription");
-		this.desc = new SearchDescription();
-	}
-	
-	public SearchDescription getDesc() {
-		return desc;
-	}
-	
-	@Override
-	public void startElement(String name, Map<String, String> attributes) {
-		if ( ! name.equals("OpenSearchDescription") ) { //Minor bootstrapping hack
-			super.startElement(name, attributes);
-		}
-	}
-	
-	@Override
-	protected ElementParser createChildParser(String tagName) {
-		
-		if ( tagName.equals("Url")) {
-			return new UrlParser(desc);
-		} 
-		
-		return super.createChildParser(tagName);
-	}
+
+    private SearchDescription desc;
+
+    public OpenSearchParser() {
+        super("OpenSearchDescription");
+        this.desc = new SearchDescription();
+    }
+
+    public SearchDescription getDesc() {
+        return desc;
+    }
+
+    @Override
+    public void startElement(String name, Map<String, String> attributes) {
+        if ( ! name.equals("OpenSearchDescription") ) { //Minor bootstrapping hack
+            super.startElement(name, attributes);
+        }
+    }
+
+    @Override
+    protected ElementParser createChildParser(String tagName) {
+
+        if ( tagName.equals("Url")) {
+            return new UrlParser(desc);
+        }
+
+        return super.createChildParser(tagName);
+    }
 
 
 }

--- a/src/net/nightwhistler/nucular/parser/opensearch/SearchDescription.java
+++ b/src/net/nightwhistler/nucular/parser/opensearch/SearchDescription.java
@@ -30,13 +30,13 @@ import static jedi.functional.FunctionalPrimitives.firstOption;
 
 public class SearchDescription {
 
-	private List<Link> links = new ArrayList<Link>();
-	
-	public void addLink( Link link ) {
-		this.links.add(link);
-	}
-	
-	public Option<Link> getSearchLink() {
-		return firstOption( this.links, l -> AtomConstants.TYPE_ATOM.equals( l.getType() ) );
-	}
+    private List<Link> links = new ArrayList<Link>();
+
+    public void addLink( Link link ) {
+        this.links.add(link);
+    }
+
+    public Option<Link> getSearchLink() {
+        return firstOption( this.links, l -> AtomConstants.TYPE_ATOM.equals( l.getType() ) );
+    }
 }

--- a/src/net/nightwhistler/nucular/parser/opensearch/UrlParser.java
+++ b/src/net/nightwhistler/nucular/parser/opensearch/UrlParser.java
@@ -26,22 +26,22 @@ import java.util.Map;
 
 public class UrlParser extends ElementParser {
 
-	private SearchDescription element;
-	
-	public UrlParser(SearchDescription parent) {
-		super("Url");
-		this.element = parent;
-	}	
-	
-	@Override
-	public void setAttributes(Map<String, String> attributes) {
-		Link link = new Link(
-				attributes.get("template"),
-				attributes.get("type"),
-				attributes.get("rel"),
-                attributes.get("title"));
-		
-		this.element.addLink(link);
-	}
+    private SearchDescription element;
+
+    public UrlParser(SearchDescription parent) {
+        super("Url");
+        this.element = parent;
+    }
+
+    @Override
+    public void setAttributes(Map<String, String> attributes) {
+        Link link = new Link(
+            attributes.get("template"),
+            attributes.get("type"),
+            attributes.get("rel"),
+            attributes.get("title"));
+
+        this.element.addLink(link);
+    }
 
 }

--- a/src/net/nightwhistler/pageturner/Configuration.java
+++ b/src/net/nightwhistler/pageturner/Configuration.java
@@ -60,49 +60,49 @@ import static net.nightwhistler.pageturner.PlatformUtil.isAtLeast;
 /**
  * Application configuration class which provides a friendly API to the various
  * settings available.
- * 
+ *
  * @author Alex Kuiper
- * 
+ *
  */
 @ContextSingleton
 public class Configuration {
 
-	private SharedPreferences settings;
-	private Context context;
+    private SharedPreferences settings;
+    private Context context;
 
-	private Map<String, FontFamily> fontCache = new HashMap<>();
+    private Map<String, FontFamily> fontCache = new HashMap<>();
 
-	public static enum ScrollStyle {
-		ROLLING_BLIND, PAGE_TIMER
-	}
+    public static enum ScrollStyle {
+        ROLLING_BLIND, PAGE_TIMER
+    }
 
-	public static enum AnimationStyle {
-		CURL, SLIDE, NONE
-	}
+    public static enum AnimationStyle {
+        CURL, SLIDE, NONE
+    }
 
-	public static enum OrientationLock {
-		PORTRAIT, LANDSCAPE, REVERSE_PORTRAIT, REVERSE_LANDSCAPE, NO_LOCK
-	}
+    public static enum OrientationLock {
+        PORTRAIT, LANDSCAPE, REVERSE_PORTRAIT, REVERSE_LANDSCAPE, NO_LOCK
+    }
 
-	public static enum ColourProfile {
-		DAY, NIGHT
-	}
+    public static enum ColourProfile {
+        DAY, NIGHT
+    }
 
-	public static enum LibraryView {
-		BOOKCASE, LIST
-	}
+    public static enum LibraryView {
+        BOOKCASE, LIST
+    }
 
-	public static enum CoverLabelOption {
-		ALWAYS, NEVER, WITHOUT_COVER
-	}
+    public static enum CoverLabelOption {
+        ALWAYS, NEVER, WITHOUT_COVER
+    }
 
-	public static enum LibrarySelection {
-		BY_LAST_READ, LAST_ADDED, UNREAD, BY_TITLE, BY_AUTHOR;
-	}
+    public static enum LibrarySelection {
+        BY_LAST_READ, LAST_ADDED, UNREAD, BY_TITLE, BY_AUTHOR;
+    }
 
-	public static enum ReadingDirection {
-		LEFT_TO_RIGHT, RIGHT_TO_LEFT;
-	}
+    public static enum ReadingDirection {
+        LEFT_TO_RIGHT, RIGHT_TO_LEFT;
+    }
 
     public static enum LongShortPressBehaviour {
         NORMAL, REVERSED
@@ -110,71 +110,71 @@ public class Configuration {
 
 
     public static final String BASE_OPDS_FEED = "http://www.pageturner-reader.org/opds/feeds.xml";
-	public static final String BASE_SYNC_URL = "http://api.pageturner-reader.org/progress/";
-	public static final String KEY_SYNC_SERVER = "sync_server";
+    public static final String BASE_SYNC_URL = "http://api.pageturner-reader.org/progress/";
+    public static final String KEY_SYNC_SERVER = "sync_server";
 
-	public static final String KEY_POS = "offset:";
-	public static final String KEY_IDX = "index:";
-	public static final String KEY_NAV_TAP_V = "nav_tap_v";
-	public static final String KEY_NAV_TAP_H = "nav_tap_h";
-	public static final String KEY_NAV_SWIPE_H = "nav_swipe_h";
-	public static final String KEY_NAV_SWIPE_V = "nav_swipe_v";
-	public static final String KEY_NAV_VOL = "nav_vol";
+    public static final String KEY_POS = "offset:";
+    public static final String KEY_IDX = "index:";
+    public static final String KEY_NAV_TAP_V = "nav_tap_v";
+    public static final String KEY_NAV_TAP_H = "nav_tap_h";
+    public static final String KEY_NAV_SWIPE_H = "nav_swipe_h";
+    public static final String KEY_NAV_SWIPE_V = "nav_swipe_v";
+    public static final String KEY_NAV_VOL = "nav_vol";
 
-	public static final String KEY_EMAIL = "email";
-	public static final String KEY_FULL_SCREEN = "full_screen";
-	public static final String KEY_COPY_TO_LIB = "copy_to_library";
-	public static final String KEY_STRIP_WHITESPACE = "strip_whitespace";
-	public static final String KEY_SCROLLING = "scrolling";
+    public static final String KEY_EMAIL = "email";
+    public static final String KEY_FULL_SCREEN = "full_screen";
+    public static final String KEY_COPY_TO_LIB = "copy_to_library";
+    public static final String KEY_STRIP_WHITESPACE = "strip_whitespace";
+    public static final String KEY_SCROLLING = "scrolling";
 
-	public static final String KEY_LAST_FILE = "last_file";
-	public static final String KEY_DEVICE_NAME = "device_name";
-	public static final String KEY_TEXT_SIZE = "itext_size";
+    public static final String KEY_LAST_FILE = "last_file";
+    public static final String KEY_DEVICE_NAME = "device_name";
+    public static final String KEY_TEXT_SIZE = "itext_size";
 
-	public static final String KEY_MARGIN_H = "margin_h";
-	public static final String KEY_MARGIN_V = "margin_v";
+    public static final String KEY_MARGIN_H = "margin_h";
+    public static final String KEY_MARGIN_V = "margin_v";
 
-	public static final String KEY_LINE_SPACING = "line_spacing";
+    public static final String KEY_LINE_SPACING = "line_spacing";
 
-	public static final String KEY_NIGHT_MODE = "night_mode";
-	public static final String KEY_SCREEN_ORIENTATION = "screen_orientation";
-	public static final String KEY_FONT_FACE = "font_face";
-	public static final String KEY_SERIF_FONT = "serif_font";
-	public static final String KEY_SANS_SERIF_FONT = "sans_serif_font";
+    public static final String KEY_NIGHT_MODE = "night_mode";
+    public static final String KEY_SCREEN_ORIENTATION = "screen_orientation";
+    public static final String KEY_FONT_FACE = "font_face";
+    public static final String KEY_SERIF_FONT = "serif_font";
+    public static final String KEY_SANS_SERIF_FONT = "sans_serif_font";
 
-	public static final String PREFIX_DAY = "day";
-	public static final String PREFIX_NIGHT = "night";
+    public static final String PREFIX_DAY = "day";
+    public static final String PREFIX_NIGHT = "night";
 
-	public static final String KEY_BRIGHTNESS = "bright";
-	public static final String KEY_BACKGROUND = "bg";
-	public static final String KEY_LINK = "link";
-	public static final String KEY_TEXT = "text";
+    public static final String KEY_BRIGHTNESS = "bright";
+    public static final String KEY_BACKGROUND = "bg";
+    public static final String KEY_LINK = "link";
+    public static final String KEY_TEXT = "text";
 
-	public static final String KEY_BRIGHTNESS_CTRL = "set_brightness";
-	public static final String KEY_SCROLL_STYLE = "scroll_style";
-	public static final String KEY_SCROLL_SPEED = "scroll_speed";
+    public static final String KEY_BRIGHTNESS_CTRL = "set_brightness";
+    public static final String KEY_SCROLL_STYLE = "scroll_style";
+    public static final String KEY_SCROLL_SPEED = "scroll_speed";
 
-	public static final String KEY_H_ANIMATION = "h_animation";
-	public static final String KEY_V_ANIMATION = "v_animation";
+    public static final String KEY_H_ANIMATION = "h_animation";
+    public static final String KEY_V_ANIMATION = "v_animation";
 
-	public static final String KEY_LIB_VIEW = "library_view";
-	public static final String KEY_LIB_SEL = "library_selection";
+    public static final String KEY_LIB_VIEW = "library_view";
+    public static final String KEY_LIB_SEL = "library_selection";
 
-	public static final String ACCESS_KEY = "access_key";
-	public static final String CALIBRE_SERVER = "calibre_server";
-	public static final String CALIBRE_USER = "calibre_user";
-	public static final String CALIBRE_PASSWORD = "calibre_password";
+    public static final String ACCESS_KEY = "access_key";
+    public static final String CALIBRE_SERVER = "calibre_server";
+    public static final String CALIBRE_USER = "calibre_user";
+    public static final String CALIBRE_PASSWORD = "calibre_password";
 
-	public static final String KEY_COVER_LABELS = "cover_labels";
+    public static final String KEY_COVER_LABELS = "cover_labels";
 
-	public static final String KEY_KEEP_SCREEN_ON = "keep_screen_on";
+    public static final String KEY_KEEP_SCREEN_ON = "keep_screen_on";
 
-	public static final String KEY_OFFSETS = "offsets";
-	public static final String KEY_SHOW_PAGENUM = "show_pagenum";
+    public static final String KEY_OFFSETS = "offsets";
+    public static final String KEY_SHOW_PAGENUM = "show_pagenum";
 
-	public static final String KEY_OPDS_SITES = "opds_sites";
+    public static final String KEY_OPDS_SITES = "opds_sites";
 
-	public static final String KEY_READING_DIRECTION = "reading_direction";
+    public static final String KEY_READING_DIRECTION = "reading_direction";
 
     public static final String KEY_DIM_SYSTEM_UI = "dim_system_ui";
 
@@ -182,7 +182,7 @@ public class Configuration {
 
     public static final String KEY_LONG_SHORT = "long_short";
 
-	public static final String KEY_NOOK_TOP_BUTTONS_DIRECTION = "nook_touch_top_buttons_direction";
+    public static final String KEY_NOOK_TOP_BUTTONS_DIRECTION = "nook_touch_top_buttons_direction";
 
     public static final String KEY_HIGHLIGHTS = "highlights";
 
@@ -197,31 +197,31 @@ public class Configuration {
 
     public static final String KEY_SCAN_FOLDER = "scan_folder";
     public static final String KEY_USE_SCAN_FOLDER = "use_scan_folder";
-    
-	// Flag for whether PageTurner is running on a Nook Simple Touch - an e-ink
-	// based Android device
-	
-	// NB: Believe product/model field is "NOOK" on a Nook Touch and 'NookColor'
-	// on a Nook Color
-	public static final Boolean IS_NOOK_TOUCH = "NOOK".equals(Build.PRODUCT);
 
-	// Flag for any e-ink device. Currently only supports Nook Touch but could
-	// expand to other devices like the Sony PRS-T1
-	public static final Boolean IS_EINK_DEVICE = IS_NOOK_TOUCH;
+    // Flag for whether PageTurner is running on a Nook Simple Touch - an e-ink
+    // based Android device
+
+    // NB: Believe product/model field is "NOOK" on a Nook Touch and 'NookColor'
+    // on a Nook Color
+    public static final Boolean IS_NOOK_TOUCH = "NOOK".equals(Build.PRODUCT);
+
+    // Flag for any e-ink device. Currently only supports Nook Touch but could
+    // expand to other devices like the Sony PRS-T1
+    public static final Boolean IS_EINK_DEVICE = IS_NOOK_TOUCH;
 
     //Which platform version to start text selection on.
     public static final int TEXT_SELECTION_PLATFORM_VERSION = Build.VERSION_CODES.ICE_CREAM_SANDWICH;
 
     private static final Logger LOG = LoggerFactory
-            .getLogger("Configuration");
+        .getLogger("Configuration");
 
     private String defaultSerifFont;
     private String defaultSansFont;
 
-	@Inject
-	public Configuration(Context context) {
-		this.settings = PreferenceManager.getDefaultSharedPreferences(context);
-		this.context = context;
+    @Inject
+    public Configuration(Context context) {
+        this.settings = PreferenceManager.getDefaultSharedPreferences(context);
+        this.context = context;
 
         if ( IS_NOOK_TOUCH ) {
             defaultSerifFont = "serif";
@@ -231,32 +231,32 @@ public class Configuration {
             defaultSansFont = "sans";
         }
 
-		// On Nook Touch, preset some different defaults on first load
-		// (these values work better w/ e-ink)
-		if (IS_NOOK_TOUCH && this.settings.getString(KEY_DEVICE_NAME, null) == null) {
-			SharedPreferences.Editor editor = this.settings.edit();
-			editor.putString(KEY_FONT_FACE, "sans");
-			editor.putString(KEY_SERIF_FONT, "serif");
+        // On Nook Touch, preset some different defaults on first load
+        // (these values work better w/ e-ink)
+        if (IS_NOOK_TOUCH && this.settings.getString(KEY_DEVICE_NAME, null) == null) {
+            SharedPreferences.Editor editor = this.settings.edit();
+            editor.putString(KEY_FONT_FACE, "sans");
+            editor.putString(KEY_SERIF_FONT, "serif");
 
-			editor.putInt(KEY_TEXT_SIZE, 32);
-			editor.putString(KEY_SCROLL_STYLE, "timer"); // enum is ScrollStyle.PAGE_TIMER
-			final String no_animation = AnimationStyle.NONE.name().toLowerCase(Locale.US);
-			editor.putString(KEY_H_ANIMATION, no_animation);
-			editor.putString(KEY_V_ANIMATION, no_animation);
-			editor.putInt(PREFIX_DAY + "_" + KEY_LINK,
-					Color.rgb(0x40, 0x40, 0x40));
-			editor.putInt(PREFIX_NIGHT + "_" + KEY_TEXT, Color.WHITE);
-			editor.putInt(PREFIX_NIGHT + "_" + KEY_LINK,
-					Color.rgb(0xb0, 0xb0, 0xb0));
-			editor.commit();
-		}
-	}
+            editor.putInt(KEY_TEXT_SIZE, 32);
+            editor.putString(KEY_SCROLL_STYLE, "timer"); // enum is ScrollStyle.PAGE_TIMER
+            final String no_animation = AnimationStyle.NONE.name().toLowerCase(Locale.US);
+            editor.putString(KEY_H_ANIMATION, no_animation);
+            editor.putString(KEY_V_ANIMATION, no_animation);
+            editor.putInt(PREFIX_DAY + "_" + KEY_LINK,
+                Color.rgb(0x40, 0x40, 0x40));
+            editor.putInt(PREFIX_NIGHT + "_" + KEY_TEXT, Color.WHITE);
+            editor.putInt(PREFIX_NIGHT + "_" + KEY_LINK,
+                Color.rgb(0xb0, 0xb0, 0xb0));
+            editor.commit();
+        }
+    }
 
     public String getAppVersion() {
         String version = "";
         try {
             version = context.getPackageManager().getPackageInfo(
-                    context.getPackageName(), 0).versionName;
+                context.getPackageName(), 0).versionName;
         } catch (PackageManager.NameNotFoundException e) {
             // Huh? Really?
         }
@@ -266,23 +266,23 @@ public class Configuration {
 
     public String getUserAgent() {
         return context.getString(R.string.app_name) + "-" + getAppVersion()
-                + "/" + Build.MODEL + ";Android-" + Build.VERSION.RELEASE;
+            + "/" + Build.MODEL + ";Android-" + Build.VERSION.RELEASE;
     }
-	
-	public Locale getLocale() {
-		
-		String languageSetting = settings.getString("custom_lang", "default");
-		
-		if ( "default".equalsIgnoreCase(languageSetting) ) {		
-			return Locale.getDefault();
-		}
-		
-		return new Locale(languageSetting);
-	}
+
+    public Locale getLocale() {
+
+        String languageSetting = settings.getString("custom_lang", "default");
+
+        if ( "default".equalsIgnoreCase(languageSetting) ) {
+            return Locale.getDefault();
+        }
+
+        return new Locale(languageSetting);
+    }
 
     public Class<? extends PageTurnerActivity> getLastActivity() {
         String lastActivityString = settings.getString( KEY_LAST_ACTIVITY,
-                "net.nightwhistler.pageturner.activity.ReadingActivity" );
+            "net.nightwhistler.pageturner.activity.ReadingActivity" );
 
         try {
             return (Class<? extends PageTurnerActivity>) Class.forName( lastActivityString );
@@ -296,37 +296,37 @@ public class Configuration {
         updateValue( KEY_LAST_ACTIVITY, activityClass.getCanonicalName() );
     }
 
-	public String getBaseOPDSFeed() {
-		return BASE_OPDS_FEED;
-	}
+    public String getBaseOPDSFeed() {
+        return BASE_OPDS_FEED;
+    }
 
-	public String getSyncServerURL() {
-		return settings.getString( KEY_SYNC_SERVER, BASE_SYNC_URL ).trim();
-	}
+    public String getSyncServerURL() {
+        return settings.getString( KEY_SYNC_SERVER, BASE_SYNC_URL ).trim();
+    }
 
     public boolean isAlwaysOpenLastBook() {
         return settings.getBoolean(KEY_ALWAYS_OPEN_LAST_BOOK, false);
     }
 
-	public boolean isVerticalTappingEnabled() {
-		return !isScrollingEnabled()
-				&& settings.getBoolean(KEY_NAV_TAP_V, true);
-	}
+    public boolean isVerticalTappingEnabled() {
+        return !isScrollingEnabled()
+            && settings.getBoolean(KEY_NAV_TAP_V, true);
+    }
 
-	public boolean isHorizontalTappingEnabled() {
-		return !isScrollingEnabled()
-				&& settings.getBoolean(KEY_NAV_TAP_H, true);
-	}
+    public boolean isHorizontalTappingEnabled() {
+        return !isScrollingEnabled()
+            && settings.getBoolean(KEY_NAV_TAP_H, true);
+    }
 
-	public boolean isHorizontalSwipeEnabled() {
-		return !isScrollingEnabled()
-				&& settings.getBoolean(KEY_NAV_SWIPE_H, true);
-	}
+    public boolean isHorizontalSwipeEnabled() {
+        return !isScrollingEnabled()
+            && settings.getBoolean(KEY_NAV_SWIPE_H, true);
+    }
 
-	public boolean isVerticalSwipeEnabled() {
-		return settings.getBoolean(KEY_NAV_SWIPE_V, true)
-				&& !isScrollingEnabled();
-	}
+    public boolean isVerticalSwipeEnabled() {
+        return settings.getBoolean(KEY_NAV_SWIPE_V, true)
+            && !isScrollingEnabled();
+    }
 
     public boolean isAcceptSelfSignedCertificates() {
         return settings.getBoolean(KEY_ACCEPT_SELF_SIGNED, false);
@@ -336,7 +336,7 @@ public class Configuration {
         return settings.getBoolean(KEY_ALLOW_STYLING, true);
     }
 
-	public int getLastPosition(String fileName) {
+    public int getLastPosition(String fileName) {
 
         SharedPreferences bookPrefs = getPrefsForBook(fileName);
 
@@ -347,17 +347,17 @@ public class Configuration {
         }
 
         //Fall-back to older settings
-		String bookHash = Integer.toHexString(fileName.hashCode());
+        String bookHash = Integer.toHexString(fileName.hashCode());
 
-		pos = settings.getInt(KEY_POS + bookHash, -1);
+        pos = settings.getInt(KEY_POS + bookHash, -1);
 
-		if (pos != -1) {
-			return pos;
-		}
+        if (pos != -1) {
+            return pos;
+        }
 
-		// Fall-back for even older settings.
-		return settings.getInt(KEY_POS + fileName, -1);
-	}
+        // Fall-back for even older settings.
+        return settings.getInt(KEY_POS + fileName, -1);
+    }
 
     private SharedPreferences getPrefsForBook( String fileName ) {
 
@@ -365,11 +365,11 @@ public class Configuration {
         return context.getSharedPreferences(bookHash, 0);
     }
 
-	public void setPageOffsets(String fileName, List<List<Integer>> offsets) {
+    public void setPageOffsets(String fileName, List<List<Integer>> offsets) {
 
         SharedPreferences bookPrefs = getPrefsForBook(fileName);
 
-		PageOffsets offsetsObject = PageOffsets.fromValues(this, offsets);
+        PageOffsets offsetsObject = PageOffsets.fromValues(this, offsets);
 
         try {
             String json = offsetsObject.toJSON();
@@ -377,17 +377,17 @@ public class Configuration {
         } catch ( JSONException js ) {
             LOG.error( "Error storing page offsets", js );
         }
-	}
+    }
 
-	public Option<List<List<Integer>>> getPageOffsets(String fileName) {
+    public Option<List<List<Integer>>> getPageOffsets(String fileName) {
 
         SharedPreferences bookPrefs = getPrefsForBook(fileName);
 
-		String data = bookPrefs.getString(KEY_OFFSETS, "");
+        String data = bookPrefs.getString(KEY_OFFSETS, "");
 
-		if ( data.length() == 0 ) {
-			return none();
-		}
+        if ( data.length() == 0 ) {
+            return none();
+        }
 
         try {
             PageOffsets offsets = PageOffsets.fromJSON(data);
@@ -402,7 +402,7 @@ public class Configuration {
             LOG.error( "Could not retrieve page offsets", js );
             return none();
         }
-	}
+    }
 
     public List<HighLight> getHightLights( String fileName ) {
         SharedPreferences prefs = getPrefsForBook(fileName);
@@ -421,24 +421,24 @@ public class Configuration {
 
     public LongShortPressBehaviour getLongShortPressBehaviour() {
         String value = settings.getString(KEY_LONG_SHORT,
-                LongShortPressBehaviour.NORMAL.name());
+            LongShortPressBehaviour.NORMAL.name());
         return LongShortPressBehaviour.valueOf( value.toUpperCase(Locale.US) );
     }
 
-	public ReadingDirection getReadingDirection() {
-		String value = settings.getString(KEY_READING_DIRECTION,
-                ReadingDirection.LEFT_TO_RIGHT.name());
-		return ReadingDirection.valueOf(value.toUpperCase(Locale.US));
-	}
+    public ReadingDirection getReadingDirection() {
+        String value = settings.getString(KEY_READING_DIRECTION,
+            ReadingDirection.LEFT_TO_RIGHT.name());
+        return ReadingDirection.valueOf(value.toUpperCase(Locale.US));
+    }
 
-	public void setLastPosition(String fileName, int position) {
+    public void setLastPosition(String fileName, int position) {
 
         SharedPreferences bookPrefs = getPrefsForBook(fileName);
 
-		updateValue(bookPrefs, KEY_POS, position);
-	}
+        updateValue(bookPrefs, KEY_POS, position);
+    }
 
-	public int getLastIndex(String fileName) {
+    public int getLastIndex(String fileName) {
 
         SharedPreferences bookPrefs = getPrefsForBook(fileName);
 
@@ -449,59 +449,59 @@ public class Configuration {
         }
 
         //Fall-backs to older setting in central file
-		String bookHash = Integer.toHexString(fileName.hashCode());
+        String bookHash = Integer.toHexString(fileName.hashCode());
 
-		pos = settings.getInt(KEY_IDX + bookHash, -1);
+        pos = settings.getInt(KEY_IDX + bookHash, -1);
 
-		if (pos != -1) {
-			return pos;
-		}
+        if (pos != -1) {
+            return pos;
+        }
 
-		// Fall-back for even older settings.
-		return settings.getInt(KEY_IDX + fileName, -1);
-	}
+        // Fall-back for even older settings.
+        return settings.getInt(KEY_IDX + fileName, -1);
+    }
 
-	public List<CustomOPDSSite> getCustomOPDSSites() {
+    public List<CustomOPDSSite> getCustomOPDSSites() {
 
-		String sites = settings.getString(KEY_OPDS_SITES, "[]");
+        String sites = settings.getString(KEY_OPDS_SITES, "[]");
 
-		List<CustomOPDSSite> result = new ArrayList<>();
+        List<CustomOPDSSite> result = new ArrayList<>();
 
-		try {
-			JSONArray array = new JSONArray(sites);
-			for (int i = 0; i < array.length(); i++) {
-				JSONObject obj = array.getJSONObject(i);
-				CustomOPDSSite site = fromJSON(obj);
+        try {
+            JSONArray array = new JSONArray(sites);
+            for (int i = 0; i < array.length(); i++) {
+                JSONObject obj = array.getJSONObject(i);
+                CustomOPDSSite site = fromJSON(obj);
                 result.add(site);
-			}
-		} catch (JSONException js) {
+            }
+        } catch (JSONException js) {
             LOG.error( "Could not retrieve custom opds sites", js );
-		}
+        }
 
-		importOldCalibreSite(result);
-		return result;
-	}
+        importOldCalibreSite(result);
+        return result;
+    }
 
-	private void importOldCalibreSite(List<CustomOPDSSite> sites) {
+    private void importOldCalibreSite(List<CustomOPDSSite> sites) {
 
-		if (this.getCalibreServer() != null
-				&& this.getCalibreServer().length() > 0) {
-			CustomOPDSSite calibre = new CustomOPDSSite();
-			calibre.setName(context.getString(R.string.pref_calibre_server));
-			calibre.setUrl(getCalibreServer());
-			calibre.setUserName(getCalibreUser());
-			calibre.setPassword(getCalibrePassword());
+        if (this.getCalibreServer() != null
+            && this.getCalibreServer().length() > 0) {
+            CustomOPDSSite calibre = new CustomOPDSSite();
+            calibre.setName(context.getString(R.string.pref_calibre_server));
+            calibre.setUrl(getCalibreServer());
+            calibre.setUserName(getCalibreUser());
+            calibre.setPassword(getCalibrePassword());
 
-			sites.add(calibre);
+            sites.add(calibre);
 
-			updateValue(CALIBRE_SERVER, null);
+            updateValue(CALIBRE_SERVER, null);
 
-			storeCustomOPDSSites(sites);
-		}
+            storeCustomOPDSSites(sites);
+        }
 
-	}
+    }
 
-	public void storeCustomOPDSSites(List<CustomOPDSSite> sites) {
+    public void storeCustomOPDSSites(List<CustomOPDSSite> sites) {
 
         try {
             JSONArray array = new JSONArray();
@@ -513,57 +513,57 @@ public class Configuration {
         } catch ( JSONException js ) {
             LOG.error( "Error storing custom sites", js );
         }
-	}
+    }
 
-	public void setLastIndex(String fileName, int index) {
+    public void setLastIndex(String fileName, int index) {
 
         SharedPreferences bookPrefs = getPrefsForBook(fileName);
-		updateValue(bookPrefs, KEY_IDX, index);
-	}
+        updateValue(bookPrefs, KEY_IDX, index);
+    }
 
-	public boolean isVolumeKeyNavEnabled() {
-		return !isScrollingEnabled() && settings.getBoolean(KEY_NAV_VOL, false);
-	}
+    public boolean isVolumeKeyNavEnabled() {
+        return !isScrollingEnabled() && settings.getBoolean(KEY_NAV_VOL, false);
+    }
 
-	public boolean isNookUpButtonForward() {
-		return !isScrollingEnabled()
-				&& "forward".equals(settings.getString(
-						KEY_NOOK_TOP_BUTTONS_DIRECTION, "backward"));
-	}
+    public boolean isNookUpButtonForward() {
+        return !isScrollingEnabled()
+            && "forward".equals(settings.getString(
+                    KEY_NOOK_TOP_BUTTONS_DIRECTION, "backward"));
+    }
 
-	public String getSynchronizationEmail() {
-		return settings.getString(KEY_EMAIL, "").trim();
-	}
+    public String getSynchronizationEmail() {
+        return settings.getString(KEY_EMAIL, "").trim();
+    }
 
-	public boolean isShowPageNumbers() {
-		return settings.getBoolean(KEY_SHOW_PAGENUM, true);
-	}
+    public boolean isShowPageNumbers() {
+        return settings.getBoolean(KEY_SHOW_PAGENUM, true);
+    }
 
-	public String getSynchronizationAccessKey() {
-		return settings.getString(ACCESS_KEY, "").trim();
-	}
+    public String getSynchronizationAccessKey() {
+        return settings.getString(ACCESS_KEY, "").trim();
+    }
 
     public boolean isDimSystemUI() {
         return isFullScreenEnabled() && settings.getBoolean(KEY_DIM_SYSTEM_UI, false);
     }
 
-	public boolean isSyncEnabled() {
-		String email = getSynchronizationEmail();
+    public boolean isSyncEnabled() {
+        String email = getSynchronizationEmail();
 
-		return email.length() > 0;
-	}
+        return email.length() > 0;
+    }
 
-	public boolean isFullScreenEnabled() {
-		return settings.getBoolean(KEY_FULL_SCREEN, false);
-	}
+    public boolean isFullScreenEnabled() {
+        return settings.getBoolean(KEY_FULL_SCREEN, false);
+    }
 
-	public boolean isStripWhiteSpaceEnabled() {
-		return settings.getBoolean(KEY_STRIP_WHITESPACE, false);
-	}
+    public boolean isStripWhiteSpaceEnabled() {
+        return settings.getBoolean(KEY_STRIP_WHITESPACE, false);
+    }
 
-	public boolean isScrollingEnabled() {
-		return settings.getBoolean(KEY_SCROLLING, false);
-	}
+    public boolean isScrollingEnabled() {
+        return settings.getBoolean(KEY_SCROLLING, false);
+    }
 
     public String getLastReadTitle() {
         return settings.getString(KEY_LAST_TITLE, "");
@@ -573,77 +573,77 @@ public class Configuration {
         updateValue(KEY_LAST_TITLE, title);
     }
 
-	public String getLastOpenedFile() {
-		return settings.getString(KEY_LAST_FILE, "");
-	}
+    public String getLastOpenedFile() {
+        return settings.getString(KEY_LAST_FILE, "");
+    }
 
-	public void setLastOpenedFile(String fileName) {
-		updateValue(KEY_LAST_FILE, fileName);
-	}
+    public void setLastOpenedFile(String fileName) {
+        updateValue(KEY_LAST_FILE, fileName);
+    }
 
-	public String getDeviceName() {
-		return settings.getString(KEY_DEVICE_NAME, Build.MODEL);
-	}
+    public String getDeviceName() {
+        return settings.getString(KEY_DEVICE_NAME, Build.MODEL);
+    }
 
-	public int getTextSize() {
-		return settings.getInt(KEY_TEXT_SIZE, 18);
-	}
+    public int getTextSize() {
+        return settings.getInt(KEY_TEXT_SIZE, 18);
+    }
 
-	public void setTextSize(int textSize) {
-		updateValue(KEY_TEXT_SIZE, textSize);
-	}
+    public void setTextSize(int textSize) {
+        updateValue(KEY_TEXT_SIZE, textSize);
+    }
 
-	public int getHorizontalMargin() {
-		return settings.getInt(KEY_MARGIN_H, 30);
-	}
+    public int getHorizontalMargin() {
+        return settings.getInt(KEY_MARGIN_H, 30);
+    }
 
-	public int getVerticalMargin() {
-		return settings.getInt(KEY_MARGIN_V, 25);
-	}
+    public int getVerticalMargin() {
+        return settings.getInt(KEY_MARGIN_V, 25);
+    }
 
-	public int getLineSpacing() {
-		return settings.getInt(KEY_LINE_SPACING, 0);
-	}
+    public int getLineSpacing() {
+        return settings.getInt(KEY_LINE_SPACING, 0);
+    }
 
-	public boolean isKeepScreenOn() {
-		return settings.getBoolean(KEY_KEEP_SCREEN_ON, false);
-	}
+    public boolean isKeepScreenOn() {
+        return settings.getBoolean(KEY_KEEP_SCREEN_ON, false);
+    }
 
-	public int getTheme() {
-		if (getColourProfile() == ColourProfile.NIGHT) {
-			return R.style.Theme_Sherlock;
-		} else {
-			return R.style.Theme_Sherlock_Light_DarkActionBar;
-		}
+    public int getTheme() {
+        if (getColourProfile() == ColourProfile.NIGHT) {
+            return R.style.Theme_Sherlock;
+        } else {
+            return R.style.Theme_Sherlock_Light_DarkActionBar;
+        }
 
-	}
+    }
 
-	public void setColourProfile(ColourProfile profile) {
-		if (profile == ColourProfile.DAY) {
-			updateValue(KEY_NIGHT_MODE, false);
-		} else {
-			updateValue(KEY_NIGHT_MODE, true);
-		}
-	}
+    public void setColourProfile(ColourProfile profile) {
+        if (profile == ColourProfile.DAY) {
+            updateValue(KEY_NIGHT_MODE, false);
+        } else {
+            updateValue(KEY_NIGHT_MODE, true);
+        }
+    }
 
-	public CoverLabelOption getCoverLabelOption() {
-		return CoverLabelOption.valueOf(settings.getString(KEY_COVER_LABELS,
-				CoverLabelOption.ALWAYS.name().toLowerCase(Locale.US)));
-	}
+    public CoverLabelOption getCoverLabelOption() {
+        return CoverLabelOption.valueOf(settings.getString(KEY_COVER_LABELS,
+                CoverLabelOption.ALWAYS.name().toLowerCase(Locale.US)));
+    }
 
-	public ColourProfile getColourProfile() {
-		if (settings.getBoolean(KEY_NIGHT_MODE, false)) {
-			return ColourProfile.NIGHT;
-		} else {
-			return ColourProfile.DAY;
-		}
-	}
+    public ColourProfile getColourProfile() {
+        if (settings.getBoolean(KEY_NIGHT_MODE, false)) {
+            return ColourProfile.NIGHT;
+        } else {
+            return ColourProfile.DAY;
+        }
+    }
 
-	public OrientationLock getScreenOrientation() {
-		String orientation = settings.getString(KEY_SCREEN_ORIENTATION,
-                OrientationLock.NO_LOCK.name().toLowerCase(Locale.US));
-		return OrientationLock.valueOf(orientation.toUpperCase(Locale.US));
-	}
+    public OrientationLock getScreenOrientation() {
+        String orientation = settings.getString(KEY_SCREEN_ORIENTATION,
+            OrientationLock.NO_LOCK.name().toLowerCase(Locale.US));
+        return OrientationLock.valueOf(orientation.toUpperCase(Locale.US));
+    }
 
     private void updateValue( SharedPreferences prefs, String key, Object value ) {
         SharedPreferences.Editor editor = prefs.edit();
@@ -658,105 +658,105 @@ public class Configuration {
             editor.putBoolean(key, (Boolean) value);
         } else {
             throw new IllegalArgumentException("Unsupported type: "
-                    + value.getClass().getSimpleName());
+                + value.getClass().getSimpleName());
         }
 
         editor.commit();
     }
 
-	private void updateValue(String key, Object value) {
+    private void updateValue(String key, Object value) {
         updateValue(settings, key, value);
-	}
+    }
 
-	private FontFamily loadFamilyFromAssets(String key, String baseName) {
-		Typeface basic = Typeface.createFromAsset(context.getAssets(), baseName
-                + ".otf");
-		Typeface boldFace = Typeface.createFromAsset(context.getAssets(),
-				baseName + "-Bold.otf");
-		Typeface italicFace = Typeface.createFromAsset(context.getAssets(),
-				baseName + "-Italic.otf");
-		Typeface biFace = Typeface.createFromAsset(context.getAssets(),
-				baseName + "-BoldItalic.otf");
+    private FontFamily loadFamilyFromAssets(String key, String baseName) {
+        Typeface basic = Typeface.createFromAsset(context.getAssets(), baseName
+            + ".otf");
+        Typeface boldFace = Typeface.createFromAsset(context.getAssets(),
+            baseName + "-Bold.otf");
+        Typeface italicFace = Typeface.createFromAsset(context.getAssets(),
+            baseName + "-Italic.otf");
+        Typeface biFace = Typeface.createFromAsset(context.getAssets(),
+            baseName + "-BoldItalic.otf");
 
-		FontFamily fam = new FontFamily(key, basic);
-		fam.setBoldTypeface(boldFace);
-		fam.setItalicTypeface(italicFace);
-		fam.setBoldItalicTypeface(biFace);
+        FontFamily fam = new FontFamily(key, basic);
+        fam.setBoldTypeface(boldFace);
+        fam.setItalicTypeface(italicFace);
+        fam.setBoldItalicTypeface(biFace);
 
-		return fam;
-	}
+        return fam;
+    }
 
-	private FontFamily getFontFamily(String fontKey, String defaultVal) {
+    private FontFamily getFontFamily(String fontKey, String defaultVal) {
 
-		String fontFace = settings.getString(fontKey, defaultVal);
+        String fontFace = settings.getString(fontKey, defaultVal);
 
-		if (!fontCache.containsKey(fontFace)) {
+        if (!fontCache.containsKey(fontFace)) {
 
-			if ("gen_book_bas".equals(fontFace)) {
-				fontCache.put(fontFace,
-						loadFamilyFromAssets(fontFace, "GentiumBookBasic"));
-			} else if ("gen_bas".equals(fontFace)) {
-				fontCache.put(fontFace,
-						loadFamilyFromAssets(fontFace, "GentiumBasic"));
-			} else if ("frankruehl".equalsIgnoreCase(fontFace)) {
-				fontCache.put(fontFace,
-						loadFamilyFromAssets(fontFace, "FrankRuehl"));
-			} else {
+            if ("gen_book_bas".equals(fontFace)) {
+                fontCache.put(fontFace,
+                    loadFamilyFromAssets(fontFace, "GentiumBookBasic"));
+            } else if ("gen_bas".equals(fontFace)) {
+                fontCache.put(fontFace,
+                    loadFamilyFromAssets(fontFace, "GentiumBasic"));
+            } else if ("frankruehl".equalsIgnoreCase(fontFace)) {
+                fontCache.put(fontFace,
+                    loadFamilyFromAssets(fontFace, "FrankRuehl"));
+            } else {
 
-				Typeface face = Typeface.SANS_SERIF;
-				if ("sans".equals(fontFace)) {
-					face = Typeface.SANS_SERIF;
-				} else if ("serif".equals(fontFace)) {
-					face = Typeface.SERIF;
-				} else if ("mono".equals(fontFace)) {
-					face = Typeface.MONOSPACE;
-				} else if ( "default".equals(fontFace) ) {
+                Typeface face = Typeface.SANS_SERIF;
+                if ("sans".equals(fontFace)) {
+                    face = Typeface.SANS_SERIF;
+                } else if ("serif".equals(fontFace)) {
+                    face = Typeface.SERIF;
+                } else if ("mono".equals(fontFace)) {
+                    face = Typeface.MONOSPACE;
+                } else if ( "default".equals(fontFace) ) {
                     face = Typeface.DEFAULT;
                 }
 
-				fontCache.put(fontFace, new FontFamily(fontFace, face));
-			}
-		}
+                fontCache.put(fontFace, new FontFamily(fontFace, face));
+            }
+        }
 
-		return fontCache.get(fontFace);
-	}
+        return fontCache.get(fontFace);
+    }
 
-	public FontFamily getSerifFontFamily() {
-		return getFontFamily(KEY_SERIF_FONT, defaultSerifFont );
-	}
+    public FontFamily getSerifFontFamily() {
+        return getFontFamily(KEY_SERIF_FONT, defaultSerifFont );
+    }
 
-	public FontFamily getSansSerifFontFamily() {
-		return getFontFamily(KEY_SANS_SERIF_FONT, defaultSansFont );
-	}
+    public FontFamily getSansSerifFontFamily() {
+        return getFontFamily(KEY_SANS_SERIF_FONT, defaultSansFont );
+    }
 
-	public FontFamily getDefaultFontFamily() {
-		return getFontFamily(KEY_FONT_FACE, defaultSerifFont);
-	}
+    public FontFamily getDefaultFontFamily() {
+        return getFontFamily(KEY_FONT_FACE, defaultSerifFont);
+    }
 
-	public int getBrightNess() {
-		// Brightness 0 means black screen :)
-		return Math.max(1, getProfileSetting(KEY_BRIGHTNESS, 50, 50));
-	}
+    public int getBrightNess() {
+        // Brightness 0 means black screen :)
+        return Math.max(1, getProfileSetting(KEY_BRIGHTNESS, 50, 50));
+    }
 
-	public void setBrightness(int brightness) {
-		if (getColourProfile() == ColourProfile.DAY) {
-			updateValue("day_bright", brightness);
-		} else {
-			updateValue("night_bright", brightness);
-		}
-	}
+    public void setBrightness(int brightness) {
+        if (getColourProfile() == ColourProfile.DAY) {
+            updateValue("day_bright", brightness);
+        } else {
+            updateValue("night_bright", brightness);
+        }
+    }
 
-	public int getBackgroundColor() {
-		return getProfileSetting(KEY_BACKGROUND, Color.WHITE, Color.BLACK);
-	}
+    public int getBackgroundColor() {
+        return getProfileSetting(KEY_BACKGROUND, Color.WHITE, Color.BLACK);
+    }
 
-	public int getTextColor() {
-		return getProfileSetting(KEY_TEXT, Color.BLACK, Color.GRAY);
-	}
+    public int getTextColor() {
+        return getProfileSetting(KEY_TEXT, Color.BLACK, Color.GRAY);
+    }
 
-	public int getLinkColor() {
-		return getProfileSetting(KEY_LINK, Color.BLUE, Color.rgb(255, 165, 0));
-	}
+    public int getLinkColor() {
+        return getProfileSetting(KEY_LINK, Color.BLUE, Color.rgb(255, 165, 0));
+    }
 
     public boolean isUseColoursFromCSS() {
 
@@ -772,97 +772,97 @@ public class Configuration {
     }
 
 
-	private int getProfileSetting(String setting, int dayDefault,
-			int nightDefault) {
+    private int getProfileSetting(String setting, int dayDefault,
+        int nightDefault) {
 
-		if (getColourProfile() == ColourProfile.NIGHT) {
-			return settings.getInt(PREFIX_NIGHT + "_" + setting, nightDefault);
-		} else {
-			return settings.getInt(PREFIX_DAY + "_" + setting, dayDefault);
-		}
+        if (getColourProfile() == ColourProfile.NIGHT) {
+            return settings.getInt(PREFIX_NIGHT + "_" + setting, nightDefault);
+        } else {
+            return settings.getInt(PREFIX_DAY + "_" + setting, dayDefault);
+        }
 
-	}
+    }
 
-	public boolean isBrightnessControlEnabled() {
-		return settings.getBoolean(KEY_BRIGHTNESS_CTRL, false);
-	}
+    public boolean isBrightnessControlEnabled() {
+        return settings.getBoolean(KEY_BRIGHTNESS_CTRL, false);
+    }
 
-	public ScrollStyle getAutoScrollStyle() {
-		String style = settings.getString(KEY_SCROLL_STYLE,
-				ScrollStyle.ROLLING_BLIND.name().toLowerCase(Locale.US));
-		if ("rolling_blind".equals(style)) {
-			return ScrollStyle.ROLLING_BLIND;
-		} else {
-			return ScrollStyle.PAGE_TIMER;
-		}
-	}
+    public ScrollStyle getAutoScrollStyle() {
+        String style = settings.getString(KEY_SCROLL_STYLE,
+            ScrollStyle.ROLLING_BLIND.name().toLowerCase(Locale.US));
+        if ("rolling_blind".equals(style)) {
+            return ScrollStyle.ROLLING_BLIND;
+        } else {
+            return ScrollStyle.PAGE_TIMER;
+        }
+    }
 
-	public int getScrollSpeed() {
-		return settings.getInt(KEY_SCROLL_SPEED, 20);
-	}
+    public int getScrollSpeed() {
+        return settings.getInt(KEY_SCROLL_SPEED, 20);
+    }
 
-	public AnimationStyle getHorizontalAnim() {
-		String animH = settings.getString(KEY_H_ANIMATION, AnimationStyle.SLIDE
-				.name().toLowerCase(Locale.US));
-		return AnimationStyle.valueOf(animH.toUpperCase(Locale.US));
-	}
+    public AnimationStyle getHorizontalAnim() {
+        String animH = settings.getString(KEY_H_ANIMATION, AnimationStyle.SLIDE
+            .name().toLowerCase(Locale.US));
+        return AnimationStyle.valueOf(animH.toUpperCase(Locale.US));
+    }
 
-	public AnimationStyle getVerticalAnim() {
-		String animV = settings.getString(KEY_V_ANIMATION, AnimationStyle.SLIDE
-				.name().toLowerCase(Locale.US));
-		return AnimationStyle.valueOf(animV.toUpperCase(Locale.US));
-	}
+    public AnimationStyle getVerticalAnim() {
+        String animV = settings.getString(KEY_V_ANIMATION, AnimationStyle.SLIDE
+            .name().toLowerCase(Locale.US));
+        return AnimationStyle.valueOf(animV.toUpperCase(Locale.US));
+    }
 
-	public LibraryView getLibraryView() {
-		String libView = settings.getString(KEY_LIB_VIEW, LibraryView.BOOKCASE
-                .name().toLowerCase(Locale.US));
-		return LibraryView.valueOf(libView.toUpperCase(Locale.US));
-	}
+    public LibraryView getLibraryView() {
+        String libView = settings.getString(KEY_LIB_VIEW, LibraryView.BOOKCASE
+            .name().toLowerCase(Locale.US));
+        return LibraryView.valueOf(libView.toUpperCase(Locale.US));
+    }
 
-	public void setLibraryView(LibraryView viewStyle) {
-		String libView = viewStyle.name().toLowerCase(Locale.US);
-		updateValue(KEY_LIB_VIEW, libView);
-	}
+    public void setLibraryView(LibraryView viewStyle) {
+        String libView = viewStyle.name().toLowerCase(Locale.US);
+        updateValue(KEY_LIB_VIEW, libView);
+    }
 
-	public LibrarySelection getLastLibraryQuery() {
-		String query = settings.getString(KEY_LIB_SEL,
-				LibrarySelection.LAST_ADDED.name().toLowerCase(Locale.US));
-		return LibrarySelection.valueOf(query.toUpperCase(Locale.US));
-	}
+    public LibrarySelection getLastLibraryQuery() {
+        String query = settings.getString(KEY_LIB_SEL,
+            LibrarySelection.LAST_ADDED.name().toLowerCase(Locale.US));
+        return LibrarySelection.valueOf(query.toUpperCase(Locale.US));
+    }
 
-	public void setLastLibraryQuery(LibrarySelection sel) {
-		updateValue(KEY_LIB_SEL, sel.name().toLowerCase(Locale.US));
-	}
+    public void setLastLibraryQuery(LibrarySelection sel) {
+        updateValue(KEY_LIB_SEL, sel.name().toLowerCase(Locale.US));
+    }
 
-	public String getCalibreServer() {
-		return settings.getString(CALIBRE_SERVER, "");
-	}
+    public String getCalibreServer() {
+        return settings.getString(CALIBRE_SERVER, "");
+    }
 
-	public String getCalibreUser() {
-		return settings.getString(CALIBRE_USER, "");
-	}
+    public String getCalibreUser() {
+        return settings.getString(CALIBRE_USER, "");
+    }
 
-	public String getCalibrePassword() {
-		return settings.getString(CALIBRE_PASSWORD, "");
-	}
+    public String getCalibrePassword() {
+        return settings.getString(CALIBRE_PASSWORD, "");
+    }
 
-	public Option<File> getStorageBase() {
-		return option(Environment.getExternalStorageDirectory());
-	}
+    public Option<File> getStorageBase() {
+        return option(Environment.getExternalStorageDirectory());
+    }
 
-	public Option<File> getDownloadsFolder() {
+    public Option<File> getDownloadsFolder() {
 
-		return firstOption(
-				asList(
-						ContextCompat.getExternalFilesDirs( context, "Downloads" )
-				)
-		);
-	}
+        return firstOption(
+            asList(
+                ContextCompat.getExternalFilesDirs( context, "Downloads" )
+                   )
+                           );
+    }
 
-	public Option<File> getLibraryFolder() {
+    public Option<File> getLibraryFolder() {
 
         Option<File> libraryFolder = getStorageBase().map(
-                baseFolder -> new File(baseFolder.getAbsolutePath() + "/PageTurner/Books") );
+            baseFolder -> new File(baseFolder.getAbsolutePath() + "/PageTurner/Books") );
 
         //If the library-folder on external storage exists, return it
         if ( ! isEmpty(select(libraryFolder, File::exists))) {
@@ -880,88 +880,88 @@ public class Configuration {
             } catch ( Exception e ) {}
         }
 
-		return firstOption(
-				asList(
-						ContextCompat.getExternalFilesDirs( context, "Books" )
-				)
-		);
-	}
+        return firstOption(
+            asList(
+                ContextCompat.getExternalFilesDirs( context, "Books" )
+                   )
+                           );
+    }
 
     public Option<File> getTTSFolder() {
-		return firstOption(
-				asList(
-						ContextCompat.getExternalCacheDirs( context )
-				)
-		);
+        return firstOption(
+            asList(
+                ContextCompat.getExternalCacheDirs( context )
+                   )
+                           );
     }
 
     public boolean getCopyToLibraryOnScan() {
-	return settings.getBoolean(KEY_COPY_TO_LIB, true);
+        return settings.getBoolean(KEY_COPY_TO_LIB, true);
     }
 
     public void setCopyToLibraryOnScan(boolean value) {
-	settings.edit()
-	    .putBoolean(KEY_COPY_TO_LIB, value)
-	    .commit();
+        settings.edit()
+            .putBoolean(KEY_COPY_TO_LIB, value)
+            .commit();
     }
 
     public boolean getUseCustomScanFolder() {
-	return settings.getBoolean(KEY_USE_SCAN_FOLDER, false);
+        return settings.getBoolean(KEY_USE_SCAN_FOLDER, false);
     }
 
     public void setUseCustomScanFolder(boolean value) {
-	settings.edit()
-	    .putBoolean(KEY_USE_SCAN_FOLDER, value)
-	    .commit();
+        settings.edit()
+            .putBoolean(KEY_USE_SCAN_FOLDER, value)
+            .commit();
     }
 
     /** Return the default folder path which is shown for the "scan for books" custom directory
      */
     private String getDefaultScanFolder() {
-	return Configuration.IS_NOOK_TOUCH ?
-	    "/media" : /* Nook's default internal content storage (accessible via USB) is under /media */
-	    getStorageBase().unsafeGet().getAbsolutePath() + "/eBooks";
+        return Configuration.IS_NOOK_TOUCH ?
+            "/media" : /* Nook's default internal content storage (accessible via USB) is under /media */
+            getStorageBase().unsafeGet().getAbsolutePath() + "/eBooks";
     }
 
     /** Return the folder path to show for the "scan for books" custom directory
      */
     public String getScanFolder() {
-	return settings.getString(KEY_SCAN_FOLDER, getDefaultScanFolder());
+        return settings.getString(KEY_SCAN_FOLDER, getDefaultScanFolder());
     }
 
     /** Set the folder path to show for "scan for books" custom directory.
-	Will only save a setting if the default actually changed.
+        Will only save a setting if the default actually changed.
     */
     public void setScanFolder(String value) {
-	SharedPreferences.Editor editor = settings.edit();
+        SharedPreferences.Editor editor = settings.edit();
 
-	if(value == null || value.equals(getDefaultScanFolder())) {
-	    if(!settings.contains(KEY_SCAN_FOLDER))
-		return;
-	    editor.remove(KEY_SCAN_FOLDER);
-	} else if(new File(value).isDirectory()) {
-	    editor.putString(KEY_SCAN_FOLDER, value);
-	}
+        if(value == null || value.equals(getDefaultScanFolder())) {
+            if(!settings.contains(KEY_SCAN_FOLDER))
+                return;
+            editor.remove(KEY_SCAN_FOLDER);
+        } else if(new File(value).isDirectory()) {
+            editor.putString(KEY_SCAN_FOLDER, value);
+        }
 
-	editor.commit();
+        editor.commit();
     }
 
-	/**
-	 * Returns the bytes of available memory left on the heap. Not totally sure
-	 * if it works reliably.
-	 */
-	public static double getMemoryUsage() {
-	 long max = Runtime.getRuntime().maxMemory();
+    /**
+     * Returns the bytes of available memory left on the heap. Not totally sure
+     * if it works reliably.
+     */
+    public static double getMemoryUsage() {
+        long max = Runtime.getRuntime().maxMemory();
         long used = Runtime.getRuntime().totalMemory();
 
         return (double) used / (double) max;
-	}
+    }
 
     /*
-        Returns the available bitmap memory.
-        On newer Android versions this is the same as the normaL
-        heap memory.
-     */
+      Returns the available bitmap memory.
+      On newer Android versions this is the same as the normaL
+      heap memory.
+    */
     public static double getBitmapMemoryUsage() {
 
         if ( Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB ) {

--- a/src/net/nightwhistler/pageturner/CustomOPDSSite.java
+++ b/src/net/nightwhistler/pageturner/CustomOPDSSite.java
@@ -28,43 +28,43 @@ import static jedi.option.Options.some;
 
 public class CustomOPDSSite {
 
-	private String url;
-	private String name;
-	private String description;
-	
-	private String userName;
-	private String password;
-		
-	public String getUrl() {
-		return url;
-	}
-	public void setUrl(String url) {
-		this.url = url;
-	}
-	public String getName() {
-		return name;
-	}
-	public void setName(String name) {
-		this.name = name;
-	}
-	public String getDescription() {
-		return description;
-	}
-	public void setDescription(String description) {
-		this.description = description;
-	}
-	public String getUserName() {
-		return userName;
-	}
-	public void setUserName(String userName) {
-		this.userName = userName;
-	}
-	public String getPassword() {
-		return password;
-	}
-	public void setPassword(String password) {
-		this.password = password;
-	}
+    private String url;
+    private String name;
+    private String description;
+
+    private String userName;
+    private String password;
+
+    public String getUrl() {
+        return url;
+    }
+    public void setUrl(String url) {
+        this.url = url;
+    }
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    public String getUserName() {
+        return userName;
+    }
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+    public String getPassword() {
+        return password;
+    }
+    public void setPassword(String password) {
+        this.password = password;
+    }
 
     public JSONObject toJSON() throws JSONException {
         JSONObject obj = new JSONObject();

--- a/src/net/nightwhistler/pageturner/PageTurner.java
+++ b/src/net/nightwhistler/pageturner/PageTurner.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -27,33 +27,33 @@ import org.acra.annotation.ReportsCrashes;
 import static org.acra.ReportField.*;
 
 @ReportsCrashes(formKey = "", // will not be used
-        formUri = "http://acra.pageturner-reader.org/crash",
-        customReportContent = { REPORT_ID, APP_VERSION_CODE, APP_VERSION_NAME, ANDROID_VERSION, BRAND, PHONE_MODEL, BUILD, PRODUCT, STACK_TRACE, LOGCAT, PACKAGE_NAME }
-)
-public class PageTurner extends Application {
+    formUri = "http://acra.pageturner-reader.org/crash",
+    customReportContent = { REPORT_ID, APP_VERSION_CODE, APP_VERSION_NAME, ANDROID_VERSION, BRAND, PHONE_MODEL, BUILD, PRODUCT, STACK_TRACE, LOGCAT, PACKAGE_NAME }
+                )
+                public class PageTurner extends Application {
 
-    private static boolean acraInitDone;
+                    private static boolean acraInitDone;
 
-	@Override
-	public void onCreate() {
+                    @Override
+                    public void onCreate() {
 
-        //This is a work-around because unit-tests call ACRA more than once.
-        if ( ! acraInitDone ) {
-            ACRA.init(this);
-            acraInitDone = true;
-        }
+                        //This is a work-around because unit-tests call ACRA more than once.
+                        if ( ! acraInitDone ) {
+                            ACRA.init(this);
+                            acraInitDone = true;
+                        }
 
-		if(Configuration.IS_EINK_DEVICE) { // e-ink looks better with dark-on-light (esp. Nook Touch where theming breaks light-on-dark
-			setTheme(R.style.Theme_Sherlock_Light);
-		}
-		super.onCreate();
-	}
-	
-	public static void changeLanguageSetting(Context context, Configuration pageTurnerConfig) {
-		android.content.res.Configuration config = new android.content.res.Configuration(
-				context.getResources().getConfiguration());
-	    
-		config.locale = pageTurnerConfig.getLocale();
-	    context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());	    
-	}
-}
+                        if(Configuration.IS_EINK_DEVICE) { // e-ink looks better with dark-on-light (esp. Nook Touch where theming breaks light-on-dark
+                            setTheme(R.style.Theme_Sherlock_Light);
+                        }
+                        super.onCreate();
+                    }
+
+                    public static void changeLanguageSetting(Context context, Configuration pageTurnerConfig) {
+                        android.content.res.Configuration config = new android.content.res.Configuration(
+                            context.getResources().getConfiguration());
+
+                        config.locale = pageTurnerConfig.getLocale();
+                        context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());
+                    }
+                }

--- a/src/net/nightwhistler/pageturner/PageTurnerModule.java
+++ b/src/net/nightwhistler/pageturner/PageTurnerModule.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -53,41 +53,41 @@ import java.net.URL;
 
 /**
  * This is the main Guice module for PageTurner.
- * 
+ *
  * This module determines the implementations used to
  * inject dependencies used in actually running the app.
- * 
+ *
  * @author Alex Kuiper
  *
  */
 public class PageTurnerModule extends AbstractModule {
 
-	@Override
-	protected void configure() {
-		
-		bind( LibraryService.class ).to( SqlLiteLibraryService.class );
+    @Override
+    protected void configure() {
 
-		bind( ProgressService.class ).to( PageTurnerWebProgressService.class ).in( Singleton.class );
+        bind( LibraryService.class ).to( SqlLiteLibraryService.class );
+
+        bind( ProgressService.class ).to( PageTurnerWebProgressService.class ).in( Singleton.class );
 
         bind(TTSPlaybackQueue.class).in(Singleton.class);
         bind(TextLoader.class).in(Singleton.class);
         bind(HighlightManager.class).in(Singleton.class);
 
         bind(TaskQueue.class).in(ContextSingleton.class);
-	}
-	
-	/**
-	 * Binds the HttpClient interface to the DefaultHttpClient implementation.
-	 * 
-	 * In testing we'll use a stub.
-	 * 
-	 * @return
-	 */
-	@Provides
-	@Inject
-	public HttpClient getHttpClient(Configuration config) {
-		HttpParams httpParams = new BasicHttpParams();
-		DefaultHttpClient client;
+    }
+
+    /**
+     * Binds the HttpClient interface to the DefaultHttpClient implementation.
+     *
+     * In testing we'll use a stub.
+     *
+     * @return
+     */
+    @Provides
+    @Inject
+    public HttpClient getHttpClient(Configuration config) {
+        HttpParams httpParams = new BasicHttpParams();
+        DefaultHttpClient client;
 
         if ( config.isAcceptSelfSignedCertificates() ) {
             client = new SSLHttpClient(httpParams);
@@ -95,21 +95,21 @@ public class PageTurnerModule extends AbstractModule {
             client = new DefaultHttpClient(httpParams);
         }
 
-		for ( CustomOPDSSite site: config.getCustomOPDSSites() ) {
-			if ( site.getUserName() != null && site.getUserName().length() > 0 ) {
-				try {
-					URL url = new URL(site.getUrl());
-					client.getCredentialsProvider().setCredentials(
-						new AuthScope(url.getHost(), url.getPort()),
-						new UsernamePasswordCredentials(site.getUserName(), site.getPassword()));
-				} catch (MalformedURLException mal ) {
-					//skip to the next
-				}				
-			}
-		}		
-		
-		return client;
-	}
+        for ( CustomOPDSSite site: config.getCustomOPDSSites() ) {
+            if ( site.getUserName() != null && site.getUserName().length() > 0 ) {
+                try {
+                    URL url = new URL(site.getUrl());
+                    client.getCredentialsProvider().setCredentials(
+                        new AuthScope(url.getHost(), url.getPort()),
+                        new UsernamePasswordCredentials(site.getUserName(), site.getPassword()));
+                } catch (MalformedURLException mal ) {
+                    //skip to the next
+                }
+            }
+        }
+
+        return client;
+    }
 
     public class SSLHttpClient extends DefaultHttpClient {
 
@@ -121,7 +121,7 @@ public class PageTurnerModule extends AbstractModule {
         @Override protected ClientConnectionManager createClientConnectionManager() {
             SchemeRegistry registry = new SchemeRegistry();
             registry.register(
-                    new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
+                new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
             registry.register(new Scheme("https", new EasySSLSocketFactory(), 443));
             return new SingleClientConnManager(getParams(), registry);
         }
@@ -129,5 +129,5 @@ public class PageTurnerModule extends AbstractModule {
     }
 
 
-	
+
 }

--- a/src/net/nightwhistler/pageturner/PlatformUtil.java
+++ b/src/net/nightwhistler/pageturner/PlatformUtil.java
@@ -34,13 +34,13 @@ import java.util.List;
 
 public class PlatformUtil {
 
-	public static LayoutInflater getLayoutInflater( Context context ) {
-		if ( Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB ) {
-			return (LayoutInflater) context.getApplicationContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-		} else {
-			return (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-		}
-	}
+    public static LayoutInflater getLayoutInflater( Context context ) {
+        if ( Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB ) {
+            return (LayoutInflater) context.getApplicationContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        } else {
+            return (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        }
+    }
 
     public static boolean isRunningOnUiThread() { return Looper.getMainLooper().getThread() == Thread.currentThread(); }
 
@@ -72,7 +72,7 @@ public class PlatformUtil {
 
         final PackageManager packageManager = context.getPackageManager();
         List<ResolveInfo> list = packageManager.queryIntentActivities(intent,
-                PackageManager.MATCH_DEFAULT_ONLY);
+            PackageManager.MATCH_DEFAULT_ONLY);
         return list.size() > 0;
     }
 

--- a/src/net/nightwhistler/pageturner/TextUtil.java
+++ b/src/net/nightwhistler/pageturner/TextUtil.java
@@ -32,9 +32,9 @@ public class TextUtil {
     private static final Pattern PUNCTUATION = Pattern.compile("\\.( ?\\.)*[\"'”’]?|[\\?!] ?[\"'”’]?|, ?[\"'”’]|”");
 
     /*
-    These are titles like Mr. Mrs., etc that will often cause incorrect
-    breaks in English text. We filter them out.
-     */
+      These are titles like Mr. Mrs., etc that will often cause incorrect
+      breaks in English text. We filter them out.
+    */
     private static final String[] TITLES = { "mr", "mrs", "dr", "ms", "st" };
 
     private TextUtil() {}

--- a/src/net/nightwhistler/pageturner/activity/CatalogActivity.java
+++ b/src/net/nightwhistler/pageturner/activity/CatalogActivity.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -51,7 +51,7 @@ import static jedi.option.Options.option;
 public class CatalogActivity extends PageTurnerActivity implements CatalogParent {
 
     private static final Logger LOG = LoggerFactory
-            .getLogger("CatalogActivity");
+        .getLogger("CatalogActivity");
 
     @Nullable
     @InjectFragment(R.id.fragment_book_details)
@@ -91,8 +91,8 @@ public class CatalogActivity extends PageTurnerActivity implements CatalogParent
 
     private boolean isTwoPaneView() {
         return  getResources().getConfiguration().orientation
-                == android.content.res.Configuration.ORIENTATION_LANDSCAPE
-                && detailsFragment != null;
+            == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+            && detailsFragment != null;
     }
 
 
@@ -100,7 +100,7 @@ public class CatalogActivity extends PageTurnerActivity implements CatalogParent
     public void onFeedLoaded(Feed feed) {
 
         if ( isTwoPaneView() && feed.getSize() == 1
-                && feed.getEntries().get(0).getEpubLink() != null ) {
+            && feed.getEntries().get(0).getEpubLink() != null ) {
             loadFakeFeed(feed);
         } else {
             hideDetailsView();
@@ -129,11 +129,11 @@ public class CatalogActivity extends PageTurnerActivity implements CatalogParent
 
             Option<Fragment> fragmentOption = getCurrentVisibleFragment();
             fragmentOption.forEach( (fragment) -> {
-                if ( fragment instanceof CatalogFragment ) {
-                    LOG.debug( "Notifying fragment.");
-                    ((CatalogFragment) fragment).onBecameVisible();
-                }
-            });
+                    if ( fragment instanceof CatalogFragment ) {
+                        LOG.debug( "Notifying fragment.");
+                        ((CatalogFragment) fragment).onBecameVisible();
+                    }
+                });
 
         } else if ( baseFeedTitle != null ) {
             supportInvalidateOptionsMenu();
@@ -229,7 +229,7 @@ public class CatalogActivity extends PageTurnerActivity implements CatalogParent
         }
 
         FragmentManager.BackStackEntry entry = fragmentManager.getBackStackEntryAt(
-                fragmentManager.getBackStackEntryCount() - 1 );
+            fragmentManager.getBackStackEntryCount() - 1 );
 
 
         Option<Fragment> result = option(fragmentManager.findFragmentByTag(entry.getName()));
@@ -247,15 +247,15 @@ public class CatalogActivity extends PageTurnerActivity implements CatalogParent
 
         Option<Boolean> result = getCurrentVisibleFragment().map( fragment -> {
 
-            if ( fragment instanceof CatalogFragment ) {
-                CatalogFragment catalogFragment = (CatalogFragment) fragment;
+                if ( fragment instanceof CatalogFragment ) {
+                    CatalogFragment catalogFragment = (CatalogFragment) fragment;
 
-                catalogFragment.onSearchRequested();
-                return catalogFragment.supportsSearch();
-            }
+                    catalogFragment.onSearchRequested();
+                    return catalogFragment.supportsSearch();
+                }
 
-            return false;
-        });
+                return false;
+            });
 
         return result.getOrElse(false);
     }

--- a/src/net/nightwhistler/pageturner/activity/CatalogBookDetailsActivity.java
+++ b/src/net/nightwhistler/pageturner/activity/CatalogBookDetailsActivity.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -36,7 +36,7 @@ public class CatalogBookDetailsActivity extends PageTurnerActivity implements Ca
     @Override
     protected void onCreatePageTurnerActivity(Bundle savedInstanceState) {
         if (getResources().getConfiguration().orientation
-                == android.content.res.Configuration.ORIENTATION_LANDSCAPE) {
+            == android.content.res.Configuration.ORIENTATION_LANDSCAPE) {
             // If the screen is now in landscape mode, we can show the
             // dialog in-line with the list so we don't need this activity.
             finish();

--- a/src/net/nightwhistler/pageturner/activity/FileAdapter.java
+++ b/src/net/nightwhistler/pageturner/activity/FileAdapter.java
@@ -49,17 +49,17 @@ public class FileAdapter extends BaseAdapter {
 
         Collections.sort(items, (lhs, rhs) -> {
 
-            if ((lhs.getFile().isDirectory() && rhs.getFile().isDirectory()) ||
+                if ((lhs.getFile().isDirectory() && rhs.getFile().isDirectory()) ||
                     (!lhs.getFile().isDirectory() && !rhs.getFile().isDirectory())) {
-                return lhs.getFile().getName().compareTo(rhs.getFile().getName());
-            }
+                    return lhs.getFile().getName().compareTo(rhs.getFile().getName());
+                }
 
-            if (lhs.getFile().isDirectory()) {
-                return -1;
-            } else {
-                return 1;
-            }
-        });
+                if (lhs.getFile().isDirectory()) {
+                    return -1;
+                } else {
+                    return 1;
+                }
+            });
 
         items.add( 0, new FileItem( "[" + context.getString(R.string.import_this) + "]", folder, true));
 
@@ -114,10 +114,10 @@ public class FileAdapter extends BaseAdapter {
         }
 
         selectBox.setOnCheckedChangeListener( (buttonView, isChecked) -> {
-            if ( isChecked && itemSelectionListener != null ) {
-                this.itemSelectionListener.fileSelected( fileItem.getFile() );
-            }
-        });
+                if ( isChecked && itemSelectionListener != null ) {
+                    this.itemSelectionListener.fileSelected( fileItem.getFile() );
+                }
+            });
 
         selectBox.setFocusable(false);
 
@@ -132,4 +132,3 @@ public class FileAdapter extends BaseAdapter {
         this.itemSelectionListener = itemSelectionListener;
     }
 }
-

--- a/src/net/nightwhistler/pageturner/activity/FileBrowseActivity.java
+++ b/src/net/nightwhistler/pageturner/activity/FileBrowseActivity.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -26,14 +26,14 @@ import net.nightwhistler.pageturner.R;
 import roboguice.RoboGuice;
 
 public class FileBrowseActivity extends RoboSherlockFragmentActivity {
-	
-	@Override
-	protected void onCreate(Bundle savedInstanceState) {
-		Configuration config = RoboGuice.getInjector(this).getInstance(Configuration.class); 
-		PageTurner.changeLanguageSetting(this, config);
-		setTheme( config.getTheme() );
-		
-		super.onCreate(savedInstanceState);
-		setContentView(R.layout.activity_file_browse);
-	}
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        Configuration config = RoboGuice.getInjector(this).getInstance(Configuration.class);
+        PageTurner.changeLanguageSetting(this, config);
+        setTheme( config.getTheme() );
+
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_file_browse);
+    }
 }

--- a/src/net/nightwhistler/pageturner/activity/LibraryActivity.java
+++ b/src/net/nightwhistler/pageturner/activity/LibraryActivity.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -32,10 +32,10 @@ public class LibraryActivity extends PageTurnerActivity {
         return R.layout.activity_library;
     }
 
-	@Override
-	public void onBackPressed() {
-		libraryFragment.onBackPressed();
-	}
+    @Override
+    public void onBackPressed() {
+        libraryFragment.onBackPressed();
+    }
 
     @Override
     public boolean onSearchRequested() {

--- a/src/net/nightwhistler/pageturner/activity/ManageSitesActivity.java
+++ b/src/net/nightwhistler/pageturner/activity/ManageSitesActivity.java
@@ -41,181 +41,181 @@ import java.util.List;
 
 public class ManageSitesActivity extends RoboSherlockListActivity {
 
-	@Inject
-	Configuration config;
-	
-	private CustomOPDSSiteAdapter adapter;
-	
-	private static enum ContextAction { EDIT, DELETE };
-	
-	@Override
-	protected void onCreate(Bundle savedInstanceState) {
-		Configuration config = RoboGuice.getInjector(this).getInstance(Configuration.class); 
-		PageTurner.changeLanguageSetting(this, config);
-		setTheme( config.getTheme() );
-		
-		super.onCreate(savedInstanceState);		
-	
-		List<CustomOPDSSite> sites = config.getCustomOPDSSites();
-			
-		this.adapter = new CustomOPDSSiteAdapter(sites);
-		setListAdapter(this.adapter);
-		registerForContextMenu(getListView());
-	}
-	
-	@Override
-	public boolean onPrepareOptionsMenu(Menu menu) {
-		MenuInflater inflater = getSupportMenuInflater();
-		inflater.inflate(R.menu.edit_sites_menu, menu);
+    @Inject
+    Configuration config;
 
-		return true;
-	}
-	
-	@Override
-	public boolean onOptionsItemSelected(
-			com.actionbarsherlock.view.MenuItem item) {
-		showAddSiteDialog();
-		return true;
-	}
-		
-	@Override
-	public void onCreateContextMenu(ContextMenu menu, View v,
-			ContextMenuInfo menuInfo) {
-		
-		menu.add(Menu.NONE, ContextAction.EDIT.ordinal(), Menu.NONE, R.string.edit );
-		menu.add(Menu.NONE, ContextAction.DELETE.ordinal(), Menu.NONE, R.string.delete ); 
-		
-	}
-	
-	@Override
-	protected void onListItemClick(ListView l, View v, int position, long id) {
-		showEditDialog( adapter.getItem(position) );
-	}
-	
-	@Override
-	public boolean onContextItemSelected(MenuItem item) {
-		
-		ContextAction action = ContextAction.values()[item.getItemId()];
-		AdapterContextMenuInfo info = (AdapterContextMenuInfo) item.getMenuInfo();
-		CustomOPDSSite site = adapter.getItem(info.position);
-		
-		switch (action) {
-		
-		case EDIT:
-			showEditDialog(site);
-			break;
-		case DELETE:
-			 adapter.remove(adapter.getItem(info.position));
-			 storeSites();	
-		}		
-	   
-	    return true;
-	}
-	
-	private void storeSites() {
-		List<CustomOPDSSite> sites = new ArrayList<CustomOPDSSite>();
-		for ( int i=0; i < adapter.getCount(); i++ ) {
-			sites.add( adapter.getItem(i));
-		}
-		
-		config.storeCustomOPDSSites(sites);
-	}
-	
-	private void showEditDialog(final CustomOPDSSite site) {
-		showSiteDialog(R.string.edit_site, site);		
-	}
-	
-	private void showAddSiteDialog() {		
-		showSiteDialog(R.string.add_site, null);
-	}
-	
-	private void showSiteDialog(int titleResource, final CustomOPDSSite siteParam ) {
-		
-		final CustomOPDSSite site;
-		
-		if ( siteParam == null ) {
-			site = new CustomOPDSSite();
-		} else {
-			site = siteParam;
-		}
-		
-		AlertDialog.Builder builder = new AlertDialog.Builder(this);
-		
-		builder.setTitle(titleResource);
-		LayoutInflater inflater = PlatformUtil.getLayoutInflater(this);
-		
-		View layout = inflater.inflate(R.layout.edit_site, null);
-		builder.setView(layout);
-		
-		final TextView siteName = (TextView) layout.findViewById(R.id.siteName);
-		final TextView siteURL = (TextView) layout.findViewById(R.id.siteUrl);
-		final TextView siteDesc = (TextView) layout.findViewById(R.id.siteDescription);
-		final TextView userName = (TextView) layout.findViewById(R.id.username);
-		final TextView password = (TextView) layout.findViewById(R.id.password);
-		
-		siteName.setText(site.getName());
-		siteURL.setText(site.getUrl());
-		siteDesc.setText(site.getDescription());
-		userName.setText(site.getUserName());
-		password.setText(site.getPassword());
+    private CustomOPDSSiteAdapter adapter;
+
+    private static enum ContextAction { EDIT, DELETE };
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        Configuration config = RoboGuice.getInjector(this).getInstance(Configuration.class);
+        PageTurner.changeLanguageSetting(this, config);
+        setTheme( config.getTheme() );
+
+        super.onCreate(savedInstanceState);
+
+        List<CustomOPDSSite> sites = config.getCustomOPDSSites();
+
+        this.adapter = new CustomOPDSSiteAdapter(sites);
+        setListAdapter(this.adapter);
+        registerForContextMenu(getListView());
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        MenuInflater inflater = getSupportMenuInflater();
+        inflater.inflate(R.menu.edit_sites_menu, menu);
+
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(
+        com.actionbarsherlock.view.MenuItem item) {
+        showAddSiteDialog();
+        return true;
+    }
+
+    @Override
+    public void onCreateContextMenu(ContextMenu menu, View v,
+        ContextMenuInfo menuInfo) {
+
+        menu.add(Menu.NONE, ContextAction.EDIT.ordinal(), Menu.NONE, R.string.edit );
+        menu.add(Menu.NONE, ContextAction.DELETE.ordinal(), Menu.NONE, R.string.delete );
+
+    }
+
+    @Override
+    protected void onListItemClick(ListView l, View v, int position, long id) {
+        showEditDialog( adapter.getItem(position) );
+    }
+
+    @Override
+    public boolean onContextItemSelected(MenuItem item) {
+
+        ContextAction action = ContextAction.values()[item.getItemId()];
+        AdapterContextMenuInfo info = (AdapterContextMenuInfo) item.getMenuInfo();
+        CustomOPDSSite site = adapter.getItem(info.position);
+
+        switch (action) {
+
+        case EDIT:
+            showEditDialog(site);
+            break;
+        case DELETE:
+            adapter.remove(adapter.getItem(info.position));
+            storeSites();
+        }
+
+        return true;
+    }
+
+    private void storeSites() {
+        List<CustomOPDSSite> sites = new ArrayList<CustomOPDSSite>();
+        for ( int i=0; i < adapter.getCount(); i++ ) {
+            sites.add( adapter.getItem(i));
+        }
+
+        config.storeCustomOPDSSites(sites);
+    }
+
+    private void showEditDialog(final CustomOPDSSite site) {
+        showSiteDialog(R.string.edit_site, site);
+    }
+
+    private void showAddSiteDialog() {
+        showSiteDialog(R.string.add_site, null);
+    }
+
+    private void showSiteDialog(int titleResource, final CustomOPDSSite siteParam ) {
+
+        final CustomOPDSSite site;
+
+        if ( siteParam == null ) {
+            site = new CustomOPDSSite();
+        } else {
+            site = siteParam;
+        }
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+
+        builder.setTitle(titleResource);
+        LayoutInflater inflater = PlatformUtil.getLayoutInflater(this);
+
+        View layout = inflater.inflate(R.layout.edit_site, null);
+        builder.setView(layout);
+
+        final TextView siteName = (TextView) layout.findViewById(R.id.siteName);
+        final TextView siteURL = (TextView) layout.findViewById(R.id.siteUrl);
+        final TextView siteDesc = (TextView) layout.findViewById(R.id.siteDescription);
+        final TextView userName = (TextView) layout.findViewById(R.id.username);
+        final TextView password = (TextView) layout.findViewById(R.id.password);
+
+        siteName.setText(site.getName());
+        siteURL.setText(site.getUrl());
+        siteDesc.setText(site.getDescription());
+        userName.setText(site.getUserName());
+        password.setText(site.getPassword());
 
         builder.setPositiveButton(R.string.save, (dialog, which) -> {
-            if ( siteName.getText().toString().trim().length() == 0 ) {
-                Toast.makeText(ManageSitesActivity.this, R.string.msg_name_blank, Toast.LENGTH_SHORT).show();
-                return;
+                if ( siteName.getText().toString().trim().length() == 0 ) {
+                    Toast.makeText(ManageSitesActivity.this, R.string.msg_name_blank, Toast.LENGTH_SHORT).show();
+                    return;
+                }
+
+                if ( siteURL.getText().toString().trim().length() == 0 ) {
+                    Toast.makeText(ManageSitesActivity.this, R.string.msg_url_blank, Toast.LENGTH_SHORT).show();
+                    return;
+                }
+
+                site.setName(siteName.getText().toString());
+                site.setDescription(siteDesc.getText().toString());
+                site.setUrl(siteURL.getText().toString());
+                site.setUserName(userName.getText().toString());
+                site.setPassword(password.getText().toString());
+
+                if ( siteParam == null ) {
+                    adapter.add(site);
+                }
+
+                storeSites();
+                adapter.notifyDataSetChanged();
+                dialog.dismiss();
+            });
+
+        builder.setNegativeButton(android.R.string.cancel, null );
+
+        builder.show();
+    }
+
+    private class CustomOPDSSiteAdapter extends ArrayAdapter<CustomOPDSSite> {
+        public CustomOPDSSiteAdapter(List<CustomOPDSSite> sites) {
+            super(ManageSitesActivity.this, 0, sites);
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+
+            View view;
+
+            if ( convertView != null ) {
+                view = convertView;
+            } else {
+                view = ( (LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE) ).inflate(R.layout.manage_sites, null);
             }
 
-            if ( siteURL.getText().toString().trim().length() == 0 ) {
-                Toast.makeText(ManageSitesActivity.this, R.string.msg_url_blank, Toast.LENGTH_SHORT).show();
-                return;
-            }
+            TextView siteName = (TextView) view.findViewById( R.id.siteName );
+            TextView description = (TextView) view.findViewById( R.id.siteDescription );
 
-            site.setName(siteName.getText().toString());
-            site.setDescription(siteDesc.getText().toString());
-            site.setUrl(siteURL.getText().toString());
-            site.setUserName(userName.getText().toString());
-            site.setPassword(password.getText().toString());
+            CustomOPDSSite site = this.getItem(position);
+            siteName.setText( site.getName() );
+            description.setText( site.getDescription() );
 
-            if ( siteParam == null ) {
-                adapter.add(site);
-            }
+            return view;
+        }
 
-            storeSites();
-            adapter.notifyDataSetChanged();
-            dialog.dismiss();
-        });
-		
-		builder.setNegativeButton(android.R.string.cancel, null );		
-	
-		builder.show();	
-	}
-
-	private class CustomOPDSSiteAdapter extends ArrayAdapter<CustomOPDSSite> {
-		public CustomOPDSSiteAdapter(List<CustomOPDSSite> sites) {
-			super(ManageSitesActivity.this, 0, sites);
-		}		
-		
-		@Override
-		public View getView(int position, View convertView, ViewGroup parent) {
-			
-			View view;
-			
-			if ( convertView != null ) {
-				view = convertView;
-			} else {
-				view = ( (LayoutInflater) getSystemService(Context.LAYOUT_INFLATER_SERVICE) ).inflate(R.layout.manage_sites, null);
-			}
-			
-			TextView siteName = (TextView) view.findViewById( R.id.siteName );
-			TextView description = (TextView) view.findViewById( R.id.siteDescription );
-			
-			CustomOPDSSite site = this.getItem(position);
-			siteName.setText( site.getName() );
-			description.setText( site.getDescription() );
-			
-			return view;
-		}
-		
-	}
+    }
 
 }

--- a/src/net/nightwhistler/pageturner/activity/MediaButtonReceiver.java
+++ b/src/net/nightwhistler/pageturner/activity/MediaButtonReceiver.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -27,45 +27,45 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Helper class which converts media-button events into PageTurner-specific events.
- * 
+ *
  * Since a BroadCastReceiver for MediaButton events has to be specified
  * by class-name, the created instance will have no access to the activity.
- * 
+ *
  * To work around this problem, this class will re-broadcast any media
  * events as pageturner.media.key events, which can then be picked up
  * by an internal class inside an Activity or Fragment.
- * 
+ *
  * @author Alex Kuiper
  *
  */
 public class MediaButtonReceiver extends BroadcastReceiver {
 
-	private static final Logger LOG = LoggerFactory
-			.getLogger("MediaButtonReveiver");
-	
-	public static final String INTENT_PAGETURNER_MEDIA = "pageturner.media.key";
+    private static final Logger LOG = LoggerFactory
+        .getLogger("MediaButtonReveiver");
 
-	@Override
-	public void onReceive(Context context, Intent intent) {
+    public static final String INTENT_PAGETURNER_MEDIA = "pageturner.media.key";
 
-		String intentAction = intent.getAction();
-		if (Intent.ACTION_MEDIA_BUTTON.equals(intentAction)) {
+    @Override
+    public void onReceive(Context context, Intent intent) {
 
-			LOG.info("Received media button, re-broadcasting as PageTurnerMediaKey");
+        String intentAction = intent.getAction();
+        if (Intent.ACTION_MEDIA_BUTTON.equals(intentAction)) {
 
-			KeyEvent event = intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT);
+            LOG.info("Received media button, re-broadcasting as PageTurnerMediaKey");
+
+            KeyEvent event = intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT);
 
             if ( event != null ) {
-			    Intent myIntent = new Intent(INTENT_PAGETURNER_MEDIA);
-			    myIntent.putExtra("action", event.getAction());
-			    myIntent.putExtra("keyCode", event.getKeyCode());
+                Intent myIntent = new Intent(INTENT_PAGETURNER_MEDIA);
+                myIntent.putExtra("action", event.getAction());
+                myIntent.putExtra("keyCode", event.getKeyCode());
 
-			    context.sendBroadcast(myIntent);
+                context.sendBroadcast(myIntent);
             }
-		}
+        }
 
-		if (isOrderedBroadcast()) {
-			abortBroadcast();
-		}
-	}
+        if (isOrderedBroadcast()) {
+            abortBroadcast();
+        }
+    }
 }

--- a/src/net/nightwhistler/pageturner/activity/NavigationAdapter.java
+++ b/src/net/nightwhistler/pageturner/activity/NavigationAdapter.java
@@ -50,8 +50,8 @@ public class NavigationAdapter extends BaseExpandableListAdapter {
     private static final Logger LOG = LoggerFactory.getLogger("NavigationAdapter");
 
     public NavigationAdapter( Context context, List<NavigationCallback> items,
-                              Functor2<List<NavigationCallback>, Integer,
-                                      ExpandableListView> subListProvider, int level ) {
+        Functor2<List<NavigationCallback>, Integer,
+        ExpandableListView> subListProvider, int level ) {
         this.context = context;
         this.subListProvider = subListProvider;
 
@@ -73,7 +73,7 @@ public class NavigationAdapter extends BaseExpandableListAdapter {
         }
 
         View childView = childItem.map( c -> c.hasChildren() ? getChildNodeView(c,view): getChildLeafView(c, view ) )
-                .getOrElse(view);
+            .getOrElse(view);
 
         int paddingValue = (int) getDipValue( INDENT ) * ( level + 2 );
 
@@ -81,7 +81,7 @@ public class NavigationAdapter extends BaseExpandableListAdapter {
         LOG.debug( "Old value was " + childView.getPaddingLeft() );
 
         childView.setPadding( paddingValue, childView.getPaddingTop(),
-                childView.getPaddingRight(), childView.getPaddingBottom() );
+            childView.getPaddingRight(), childView.getPaddingBottom() );
 
         return childView;
     }
@@ -112,7 +112,7 @@ public class NavigationAdapter extends BaseExpandableListAdapter {
 
         if ( layout == null ) {
             layout = PlatformUtil.getLayoutInflater(context).inflate(
-                    R.layout.drawer_list_subitem, null );
+                R.layout.drawer_list_subitem, null );
         }
 
         getTextView( layout, R.id.itemText ).forEach( t -> t.setText(childItem.getTitle() ) );
@@ -146,31 +146,31 @@ public class NavigationAdapter extends BaseExpandableListAdapter {
             layout = view;
         } else {
             layout = PlatformUtil.getLayoutInflater(context).inflate(
-                    R.layout.drawer_list_item, null );
+                R.layout.drawer_list_item, null );
         }
 
         Option<TextView> textView = getTextView( layout, R.id.groupName );
         Option<ImageView> indicator = getImageView( layout, R.id.explist_indicator );
 
         indicator.forEach( ind -> {
-            if ( getChildrenCount( i ) == 0 ) {
-                ind.setVisibility( View.INVISIBLE );
-            } else {
-                ind.setVisibility( View.VISIBLE );
-                ind.setImageResource( isExpanded ? R.drawable.arrowhead_up : R.drawable.arrowhead_down );
-            }
-        });
+                if ( getChildrenCount( i ) == 0 ) {
+                    ind.setVisibility( View.INVISIBLE );
+                } else {
+                    ind.setVisibility( View.VISIBLE );
+                    ind.setImageResource( isExpanded ? R.drawable.arrowhead_up : R.drawable.arrowhead_down );
+                }
+            });
 
         NavigationCallback item = items.get(i);
 
         LOG.debug( "Getting view for index " + i + " with title "
-                + item.getTitle() + " and subtitle " + item.getSubtitle() );
+            + item.getTitle() + " and subtitle " + item.getSubtitle() );
         LOG.debug( "Is expanded? " + isExpanded );
 
         textView.match(
-                t -> t.setText(item.getTitle()),
-                () -> LOG.error("View for title not found!")
-        );
+            t -> t.setText(item.getTitle()),
+            () -> LOG.error("View for title not found!")
+                       );
 
 
         return layout;
@@ -192,7 +192,7 @@ public class NavigationAdapter extends BaseExpandableListAdapter {
     public Option<NavigationCallback> findChild(int groupId, int childId) {
 
         Option<Option<NavigationCallback>> childItem =
-                listElement(items, groupId).map(g -> g.getChild(childId));
+            listElement(items, groupId).map(g -> g.getChild(childId));
 
         return headOption( flatten(childItem) );
     }

--- a/src/net/nightwhistler/pageturner/activity/PageTurnerActivity.java
+++ b/src/net/nightwhistler/pageturner/activity/PageTurnerActivity.java
@@ -75,14 +75,14 @@ public abstract class PageTurnerActivity extends RoboSherlockFragmentActivity {
         initDrawerItems( mDrawerOptions );
 
         mToggle = new ActionBarDrawerToggleCompat(this, mDrawer, R.drawable.ic_drawer, R.string.drawer_open, R.string.drawer_close) {
-            public void onDrawerClosed(View view) {
-                PageTurnerActivity.this.onDrawerClosed(view);
-            }
+                public void onDrawerClosed(View view) {
+                    PageTurnerActivity.this.onDrawerClosed(view);
+                }
 
-            public void onDrawerOpened(View drawerView) {
-                PageTurnerActivity.this.onDrawerOpened(drawerView);
-            }
-        };
+                public void onDrawerOpened(View drawerView) {
+                    PageTurnerActivity.this.onDrawerOpened(drawerView);
+                }
+            };
 
         mToggle.setDrawerIndicatorEnabled(true);
         mDrawer.setDrawerListener(mToggle);
@@ -123,14 +123,14 @@ public abstract class PageTurnerActivity extends RoboSherlockFragmentActivity {
 
     private ExpandableListView createExpandableListView( List<NavigationCallback> items, int level ) {
         ExpandableListView e = new ExpandableListView(this) {
-            protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-                /*
-                * Adjust height
-                */
-                heightMeasureSpec = MeasureSpec.makeMeasureSpec(10000, MeasureSpec.AT_MOST);
-                super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-            }
-        };
+                protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+                    /*
+                     * Adjust height
+                     */
+                    heightMeasureSpec = MeasureSpec.makeMeasureSpec(10000, MeasureSpec.AT_MOST);
+                    super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+                }
+            };
         setClickListeners(e, new NavigationAdapter(this, items, this::createExpandableListView, level ));
         return e;
     }
@@ -140,13 +140,13 @@ public abstract class PageTurnerActivity extends RoboSherlockFragmentActivity {
         expandableListView.setAdapter( adapter );
 
         expandableListView.setOnGroupClickListener(
-                (e, v, groupId, l) -> this.onGroupClick(adapter, groupId) );
+            (e, v, groupId, l) -> this.onGroupClick(adapter, groupId) );
 
         expandableListView.setOnChildClickListener(
-                (e, v, groupId, childId, l) -> this.onChildClick(adapter, groupId, childId));
+            (e, v, groupId, childId, l) -> this.onChildClick(adapter, groupId, childId));
 
         expandableListView.setOnItemLongClickListener(
-                (av, v, position, id) -> this.onItemLongClick(adapter, position, id));
+            (av, v, position, id) -> this.onItemLongClick(adapter, position, id));
 
         expandableListView.setGroupIndicator(null);
     }
@@ -190,7 +190,7 @@ public abstract class PageTurnerActivity extends RoboSherlockFragmentActivity {
 
     protected NavigationCallback navigate( String title, Class<? extends PageTurnerActivity> classToStart ) {
         return new NavigationCallback( title ).setOnClick(
-                () -> launchActivity(classToStart));
+            () -> launchActivity(classToStart));
     }
 
     public void onDrawerClosed(View view) {
@@ -255,14 +255,14 @@ public abstract class PageTurnerActivity extends RoboSherlockFragmentActivity {
         LOG.debug( "Got onGroupClick for group " + groupId + " on level " + adapter.getLevel() );
 
         Option<Boolean> group =adapter.findGroup(groupId).map(g -> {
-            if (g.hasChildren()) {
-                return false; //Let the superclass handle it and expand the group
-            } else {
-                g.onClick();
-                closeNavigationDrawer();
-                return true;
-            }
-        });
+                if (g.hasChildren()) {
+                    return false; //Let the superclass handle it and expand the group
+                } else {
+                    g.onClick();
+                    closeNavigationDrawer();
+                    return true;
+                }
+            });
 
         return group.getOrElse( false );
     }
@@ -270,16 +270,16 @@ public abstract class PageTurnerActivity extends RoboSherlockFragmentActivity {
     protected boolean onChildClick(NavigationAdapter adapter, int groupId, int childId) {
 
         LOG.debug("Got onChildClick event for group " + groupId + " and child " + childId
-                + " on level " + adapter.getLevel() );
+            + " on level " + adapter.getLevel() );
 
         Option<NavigationCallback> childItem = adapter.findChild(groupId, childId);
 
         childItem.forEach(item -> {
-            if ( ! item.hasChildren() ) {
-                item.onClick();
-                closeNavigationDrawer();
-            }
-        });
+                if ( ! item.hasChildren() ) {
+                    item.onClick();
+                    closeNavigationDrawer();
+                }
+            });
 
         return false;
     }
@@ -291,7 +291,7 @@ public abstract class PageTurnerActivity extends RoboSherlockFragmentActivity {
         if (ExpandableListView.getPackedPositionType(id) == ExpandableListView.PACKED_POSITION_TYPE_CHILD) {
             int groupPosition = ExpandableListView.getPackedPositionGroup(id);
             int childPosition = getAdapter().getIndexForChildId( groupPosition,
-                    ExpandableListView.getPackedPositionChild(id) );
+                ExpandableListView.getPackedPositionChild(id) );
 
             Option<NavigationCallback> childItem = adapter.findChild(groupPosition, childPosition);
 
@@ -299,9 +299,9 @@ public abstract class PageTurnerActivity extends RoboSherlockFragmentActivity {
             LOG.debug("Child-item: " + childItem );
 
             childItem.match(
-                    NavigationCallback::onLongClick,
-                    () -> LOG.error( "Could not get child-item for " + position + " and id " + id )
-            );
+                NavigationCallback::onLongClick,
+                () -> LOG.error( "Could not get child-item for " + position + " and id " + id )
+                            );
 
             closeNavigationDrawer();
             return true;

--- a/src/net/nightwhistler/pageturner/activity/PageTurnerPrefsActivity.java
+++ b/src/net/nightwhistler/pageturner/activity/PageTurnerPrefsActivity.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -30,43 +30,43 @@ import net.nightwhistler.pageturner.R;
 import roboguice.RoboGuice;
 
 public class PageTurnerPrefsActivity extends RoboSherlockPreferenceActivity {
-	
-	@Override
-	public void onCreate(Bundle savedInstanceState) {
-		Configuration config = RoboGuice.getInjector(this).getInstance(Configuration.class); 
-		PageTurner.changeLanguageSetting(this, config);
-		setTheme( config.getTheme() );
-		
-		super.onCreate(savedInstanceState);
-		
-		SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this);
 
-		if ( ! settings.contains("device_name") ) {
-	 	   SharedPreferences.Editor editor = settings.edit();
-	 	   editor.putString("device_name", Build.MODEL );
-	 	   // Commit the edits!
-	 	   editor.commit();			
-		}
-		
-		addPreferencesFromResource(R.xml.pageturner_prefs);
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        Configuration config = RoboGuice.getInjector(this).getInstance(Configuration.class);
+        PageTurner.changeLanguageSetting(this, config);
+        setTheme( config.getTheme() );
 
-		final PreferenceScreen screen = getPreferenceScreen();
-		if(!Configuration.IS_NOOK_TOUCH) {
-			// Disable Nook-specific preferences
-			screen.removePreference(screen.findPreference("nook_prefs"));
-		}
-		else {
-			// Enable only builtin fonts on Nook Touch. This is because
-			// Nook Touch can't render OTF fonts (causes segfault), also most thin weighted fonts look terrible
-			// because the Nook Touch libskia uses antialiasing, but then the Nook Touch screen can't adequately
-			// render any antialiasing...
-			final String[] font_prefs = { "font_face", "serif_font", "sans_serif_font" };
-			for(String font_pref : font_prefs) {
-				ListPreference pref = (ListPreference) screen.findPreference(font_pref);
-				pref.setEntries(getResources().getStringArray(R.array.builtinFontLabels));
-				pref.setEntryValues(getResources().getStringArray(R.array.builtinFonts));
-			}
-		}
+        super.onCreate(savedInstanceState);
+
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this);
+
+        if ( ! settings.contains("device_name") ) {
+            SharedPreferences.Editor editor = settings.edit();
+            editor.putString("device_name", Build.MODEL );
+            // Commit the edits!
+            editor.commit();
+        }
+
+        addPreferencesFromResource(R.xml.pageturner_prefs);
+
+        final PreferenceScreen screen = getPreferenceScreen();
+        if(!Configuration.IS_NOOK_TOUCH) {
+            // Disable Nook-specific preferences
+            screen.removePreference(screen.findPreference("nook_prefs"));
+        }
+        else {
+            // Enable only builtin fonts on Nook Touch. This is because
+            // Nook Touch can't render OTF fonts (causes segfault), also most thin weighted fonts look terrible
+            // because the Nook Touch libskia uses antialiasing, but then the Nook Touch screen can't adequately
+            // render any antialiasing...
+            final String[] font_prefs = { "font_face", "serif_font", "sans_serif_font" };
+            for(String font_pref : font_prefs) {
+                ListPreference pref = (ListPreference) screen.findPreference(font_pref);
+                pref.setEntries(getResources().getStringArray(R.array.builtinFontLabels));
+                pref.setEntryValues(getResources().getStringArray(R.array.builtinFonts));
+            }
+        }
 
         if ( Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB ) {
 
@@ -75,5 +75,5 @@ public class PageTurnerPrefsActivity extends RoboSherlockPreferenceActivity {
 
             group.removePreference(uiPref);
         }
-	}
+    }
 }

--- a/src/net/nightwhistler/pageturner/activity/ReadingActivity.java
+++ b/src/net/nightwhistler/pageturner/activity/ReadingActivity.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -49,7 +49,7 @@ public class ReadingActivity extends PageTurnerActivity {
     private Configuration config;
 
     private static final Logger LOG = LoggerFactory
-            .getLogger("ReadingActivity");
+        .getLogger("ReadingActivity");
 
     private int searchIndex = -1;
 
@@ -76,11 +76,11 @@ public class ReadingActivity extends PageTurnerActivity {
 
             if ( readingFragment.hasSearchResults() ) {
                 List<NavigationCallback> searchCallbacks =
-                        this.readingFragment.getSearchResults();
+                    this.readingFragment.getSearchResults();
 
                 getAdapter().findGroup(this.searchIndex).match(
-                        s -> forEach(searchCallbacks, s::addChild),
-                        () -> LOG.error("Could not find Search drawer item!"));
+                    s -> forEach(searchCallbacks, s::addChild),
+                    () -> LOG.error("Could not find Search drawer item!"));
 
             }
         }
@@ -129,10 +129,10 @@ public class ReadingActivity extends PageTurnerActivity {
         }
 
         menuItems.add( new NavigationCallback(getString(R.string.open_library))
-                .setOnClick(() -> launchActivity(LibraryActivity.class)));
+            .setOnClick(() -> launchActivity(LibraryActivity.class)));
 
         menuItems.add( new NavigationCallback(getString(R.string.download))
-                .setOnClick(() -> launchActivity(CatalogActivity.class)));
+            .setOnClick(() -> launchActivity(CatalogActivity.class)));
 
         menuItems.add( new NavigationCallback(getString(R.string.prefs)).setOnClick(this::startPreferences));
 
@@ -170,8 +170,8 @@ public class ReadingActivity extends PageTurnerActivity {
         Class<? extends PageTurnerActivity> lastActivityClass = config.getLastActivity();
 
         if ( !config.isAlwaysOpenLastBook() && lastActivityClass != null
-                && lastActivityClass != ReadingActivity.class
-                && getIntent().getData() == null ) {
+            && lastActivityClass != ReadingActivity.class
+            && getIntent().getData() == null ) {
             Intent intent = new Intent(this, lastActivityClass);
 
             startActivity(intent);
@@ -186,22 +186,22 @@ public class ReadingActivity extends PageTurnerActivity {
         return true;
     }
 
-	@Override
-	public void onWindowFocusChanged(boolean hasFocus) {
-		readingFragment.onWindowFocusChanged(hasFocus);
-	}
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        readingFragment.onWindowFocusChanged(hasFocus);
+    }
 
-	public void onMediaButtonEvent(View view) {
-		this.readingFragment.onMediaButtonEvent(view.getId());
-	}
+    public void onMediaButtonEvent(View view) {
+        this.readingFragment.onMediaButtonEvent(view.getId());
+    }
 
-	@Override
-	public boolean onTouchEvent(MotionEvent event) {
-		return readingFragment.onTouchEvent(event);
-	}
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        return readingFragment.onTouchEvent(event);
+    }
 
-	@Override
-	public boolean dispatchKeyEvent(KeyEvent event) {
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
 
         int action = event.getAction();
         int keyCode = event.getKeyCode();
@@ -216,7 +216,7 @@ public class ReadingActivity extends PageTurnerActivity {
         }
 
         return super.dispatchKeyEvent(event);
-	}
+    }
 
     @Override
     protected void beforeLaunchActivity() {

--- a/src/net/nightwhistler/pageturner/animation/Animations.java
+++ b/src/net/nightwhistler/pageturner/animation/Animations.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -24,87 +24,87 @@ import android.view.animation.TranslateAnimation;
 
 public class Animations {
 
-	public static final int DURATION = 300;
-	
-	public static Animation inFromRightAnimation() {
+    public static final int DURATION = 300;
 
-    	Animation inFromRight = new TranslateAnimation(
-    			Animation.RELATIVE_TO_PARENT,  +1.0f, Animation.RELATIVE_TO_PARENT,  0.0f,
-    			Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f
-    	);
-    	inFromRight.setDuration(DURATION);
-    	inFromRight.setInterpolator(new AccelerateInterpolator());
-    	return inFromRight;
+    public static Animation inFromRightAnimation() {
+
+        Animation inFromRight = new TranslateAnimation(
+            Animation.RELATIVE_TO_PARENT,  +1.0f, Animation.RELATIVE_TO_PARENT,  0.0f,
+            Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f
+                                                       );
+        inFromRight.setDuration(DURATION);
+        inFromRight.setInterpolator(new AccelerateInterpolator());
+        return inFromRight;
     }
-    
+
     public static Animation outToLeftAnimation() {
-    	Animation outtoLeft = new TranslateAnimation(
-    			Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,  -1.0f,
-    			Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f
-    	);
-    	outtoLeft.setDuration(DURATION);
-    	outtoLeft.setInterpolator(new AccelerateInterpolator());
-    	return outtoLeft;
+        Animation outtoLeft = new TranslateAnimation(
+            Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,  -1.0f,
+            Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f
+                                                     );
+        outtoLeft.setDuration(DURATION);
+        outtoLeft.setInterpolator(new AccelerateInterpolator());
+        return outtoLeft;
     }
 
     public static Animation inFromLeftAnimation() {
-    	Animation inFromLeft = new TranslateAnimation(
-    			Animation.RELATIVE_TO_PARENT,  -1.0f, Animation.RELATIVE_TO_PARENT,  0.0f,
-    			Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f
-    	);
-    	inFromLeft.setDuration(DURATION);
-    	inFromLeft.setInterpolator(new AccelerateInterpolator());
-    	return inFromLeft;
+        Animation inFromLeft = new TranslateAnimation(
+            Animation.RELATIVE_TO_PARENT,  -1.0f, Animation.RELATIVE_TO_PARENT,  0.0f,
+            Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f
+                                                      );
+        inFromLeft.setDuration(DURATION);
+        inFromLeft.setInterpolator(new AccelerateInterpolator());
+        return inFromLeft;
     }
-    
+
     public static Animation outToRightAnimation() {
-    	Animation outtoRight = new TranslateAnimation(
-    			Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,  +1.0f,
-    			Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f
-    	);
-    	outtoRight.setDuration(DURATION);
-    	outtoRight.setInterpolator(new AccelerateInterpolator());
-    	return outtoRight;
+        Animation outtoRight = new TranslateAnimation(
+            Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,  +1.0f,
+            Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f
+                                                      );
+        outtoRight.setDuration(DURATION);
+        outtoRight.setInterpolator(new AccelerateInterpolator());
+        return outtoRight;
     }
-    
+
     public static Animation outToBottomAnimation() {
-    	Animation outtoRight = new TranslateAnimation(    			
-    			Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f,
-    			Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,  +1.0f
-    	);
-    	outtoRight.setDuration(DURATION);
-    	outtoRight.setInterpolator(new AccelerateInterpolator());
-    	return outtoRight;
+        Animation outtoRight = new TranslateAnimation(
+            Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f,
+            Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,  +1.0f
+                                                      );
+        outtoRight.setDuration(DURATION);
+        outtoRight.setInterpolator(new AccelerateInterpolator());
+        return outtoRight;
     }
-    
+
     public static Animation inFromTopAnimation() {
-    	Animation outtoRight = new TranslateAnimation(    			
-    			Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f,
-    			Animation.RELATIVE_TO_PARENT,  -1.0f, Animation.RELATIVE_TO_PARENT,  0.0f
-    	);
-    	outtoRight.setDuration(DURATION);
-    	outtoRight.setInterpolator(new AccelerateInterpolator());
-    	return outtoRight;
+        Animation outtoRight = new TranslateAnimation(
+            Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f,
+            Animation.RELATIVE_TO_PARENT,  -1.0f, Animation.RELATIVE_TO_PARENT,  0.0f
+                                                      );
+        outtoRight.setDuration(DURATION);
+        outtoRight.setInterpolator(new AccelerateInterpolator());
+        return outtoRight;
     }
-    
+
     public static Animation inFromBottomAnimation() {
-    	Animation outtoRight = new TranslateAnimation(    			
-    			Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f,
-    			Animation.RELATIVE_TO_PARENT,  +1.0f, Animation.RELATIVE_TO_PARENT,  0.0f
-    	);
-    	outtoRight.setDuration(DURATION);
-    	outtoRight.setInterpolator(new AccelerateInterpolator());
-    	return outtoRight;
+        Animation outtoRight = new TranslateAnimation(
+            Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f,
+            Animation.RELATIVE_TO_PARENT,  +1.0f, Animation.RELATIVE_TO_PARENT,  0.0f
+                                                      );
+        outtoRight.setDuration(DURATION);
+        outtoRight.setInterpolator(new AccelerateInterpolator());
+        return outtoRight;
     }
-    
+
     public static Animation outToTopAnimation() {
-    	Animation outtoRight = new TranslateAnimation(    			
-    			Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f,
-    			Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,  -1.0f
-    	);
-    	outtoRight.setDuration(DURATION);
-    	outtoRight.setInterpolator(new AccelerateInterpolator());
-    	return outtoRight;
+        Animation outtoRight = new TranslateAnimation(
+            Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,   0.0f,
+            Animation.RELATIVE_TO_PARENT,  0.0f, Animation.RELATIVE_TO_PARENT,  -1.0f
+                                                      );
+        outtoRight.setDuration(DURATION);
+        outtoRight.setInterpolator(new AccelerateInterpolator());
+        return outtoRight;
     }
-    
+
 }

--- a/src/net/nightwhistler/pageturner/animation/Animator.java
+++ b/src/net/nightwhistler/pageturner/animation/Animator.java
@@ -22,42 +22,42 @@ import android.graphics.Canvas;
 
 /**
  * Interface for animated transitions for a textview.
- * 
+ *
  * @author Alex Kuiper
  *
  */
 public interface Animator {
 
-	/**
-	 * Returns the speed of this animation in FPS.
-	 * 
-	 * @return
-	 */
-	int getAnimationSpeed();
-	
-	/**
-	 * Advances the animation by 1 frame.
-	 */
-	void advanceOneFrame();
-	
-	
-	/**
-	 * Draw an animation frame on the given Canvas.
-	 * 
-	 * @param canvas
-	 */
-	void draw( Canvas canvas );
-	
-	/**
-	 * Checks if this Animator is done animating.
-	 * 
-	 * @return
-	 */
-	boolean isFinished();
-	
-	/**
-	 * Stop the animation.
-	 */
-	void stop();
-	
+    /**
+     * Returns the speed of this animation in FPS.
+     *
+     * @return
+     */
+    int getAnimationSpeed();
+
+    /**
+     * Advances the animation by 1 frame.
+     */
+    void advanceOneFrame();
+
+
+    /**
+     * Draw an animation frame on the given Canvas.
+     *
+     * @param canvas
+     */
+    void draw( Canvas canvas );
+
+    /**
+     * Checks if this Animator is done animating.
+     *
+     * @return
+     */
+    boolean isFinished();
+
+    /**
+     * Stop the animation.
+     */
+    void stop();
+
 }

--- a/src/net/nightwhistler/pageturner/animation/PageCurlAnimator.java
+++ b/src/net/nightwhistler/pageturner/animation/PageCurlAnimator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -24,621 +24,621 @@ import android.text.TextPaint;
 
 /**
  * PageCurl animator, simulates flipping pages.
- * 
+ *
  * All credit for this goes to Moritz 'Moss' Wundke (b.thax.dcg@gmail.com),
  * since it's just an adapted and simplified version of his PageCurlView.
- * 
+ *
  * The original project is here: http://code.google.com/p/android-page-curl/
  *
  * @author Alex Kuiper
  *
  */
 public class PageCurlAnimator implements Animator {
-		
-	
-	// Debug text paint stuff
-	private Paint mTextPaint;
-	private TextPaint mTextPaintShadow;
-	
-	/** Px / Draw call */
-	private int mCurlSpeed;
-	
-	/** Fixed update time used to create a smooth curl animation */
-	//private int mUpdateRate;
-	
-	/** The initial offset for x and y axis movements */
-	private int mInitialEdgeOffset;	
-		
-	/** Maximum radius a page can be flipped, by default it's the width of the view */
-	private float mFlipRadius;
-	
-	/** Point used to move */
-	private Vector2D mMovement;	
-	
-	/** Movement point form the last frame */
-	private Vector2D mOldMovement;
-	
-	/** Page curl edge */
-	private Paint mCurlEdgePaint;
-	
-	/** Our points used to define the current clipping paths in our draw call */
-	private Vector2D mA, mB, mC, mD, mE, mF, mOrigin;	
-	
-	/** If false no draw call has been done */
-	private boolean bViewDrawn;
-	
-	/** Defines the flip direction that is currently considered */
-	private boolean bFlipRight;
-		
-	/** LAGACY The current foreground */
-	private Bitmap mForeground;
-	
-	/** LAGACY The current background */
-	private Bitmap mBackground;		
-	
-	private int backgroundColor = Color.WHITE;
-	private int edgeColor = Color.BLACK;
 
-	private boolean started = false;
-	private boolean finished = false;
-	
-	private boolean drawDebugEnabled = false;
-	
-	public PageCurlAnimator(boolean flipRight) {
-		this.bFlipRight = flipRight;
-		//this.drawDebugEnabled = true;
-		init();
-	}
-	
-	public void setDrawDebugEnabled(boolean drawDebugEnabled) {
-		this.drawDebugEnabled = drawDebugEnabled;
-	}
 
-	@Override
-	public synchronized void advanceOneFrame() {
-		
-		started = true;
-		
-		if ( finished || mOrigin == null ) {
-			return;
-		}
-		
-		int width = getWidth();
-				
-		// Handle speed
-		float curlSpeed = mCurlSpeed;
-		if ( !bFlipRight ) {
-			curlSpeed *= -1;
-		}
-		
-		// Move us
-		mMovement.x += curlSpeed;
-		mMovement = CapMovement(mMovement, false);
-		
-		// Create values
-		doSimpleCurl();
-		
-		// Check for endings :D
-		if (mA.x < 1 || mA.x > width - 1) {
-			finished = true;
-			
-			ResetClipEdge();
-			
-			// Create values
-			doSimpleCurl();			
-		}
-	}
-	
-	public void setBackgroundColor(int backgroundColor) {
-		this.backgroundColor = backgroundColor;
-	}
-	
-	public void setEdgeColor( int edgeColor ) {
-		this.edgeColor = edgeColor;
-	}
-	
-	private void drawDebug(Canvas canvas)
-	{
-		float posX = 10;
-		float posY = 20;
-		
-		Paint paint = new Paint();
-		paint.setStrokeWidth(5);
-		paint.setStyle(Style.FILL);
-		
-		paint.setColor(Color.BLACK);
-		
-		canvas.drawCircle(mOrigin.x, mOrigin.y, getWidth(), paint);
-		
-		paint.setStrokeWidth(3);
-		paint.setColor(Color.RED);		
-		canvas.drawCircle(mOrigin.x, mOrigin.y, getWidth(), paint);
-		
-		paint.setStrokeWidth(5);
-		paint.setColor(Color.BLACK);
-		canvas.drawLine(mOrigin.x, mOrigin.y, mMovement.x, mMovement.y, paint);
-		
-		paint.setStrokeWidth(3);
-		paint.setColor(Color.RED);
-		canvas.drawLine(mOrigin.x, mOrigin.y, mMovement.x, mMovement.y, paint);
-		
-		posY = debugDrawPoint(canvas,"A",mA,Color.RED,posX,posY);
-		posY = debugDrawPoint(canvas,"B",mB,Color.GREEN,posX,posY);
-		posY = debugDrawPoint(canvas,"C",mC,Color.BLUE,posX,posY);
-		posY = debugDrawPoint(canvas,"D",mD,Color.CYAN,posX,posY);
-		posY = debugDrawPoint(canvas,"E",mE,Color.YELLOW,posX,posY);
-		posY = debugDrawPoint(canvas,"F",mF,Color.LTGRAY,posX,posY);
-		posY = debugDrawPoint(canvas,"Mov",mMovement,Color.DKGRAY,posX,posY);
-		posY = debugDrawPoint(canvas,"Origin",mOrigin,Color.MAGENTA,posX,posY);
-		
-		/**/
-	}
-	
-	private float debugDrawPoint(Canvas canvas, String name, Vector2D point, int color, float posX, float posY) {	
-		return debugDrawPoint(canvas,name+" "+point.toString(),point.x, point.y, color, posX, posY);
-	}
-	
-	private float debugDrawPoint(Canvas canvas, String name, float X, float Y, int color, float posX, float posY) {
-		mTextPaint.setColor(color);
-		drawTextShadowed(canvas,name,posX , posY, mTextPaint,mTextPaintShadow);
-		Paint paint = new Paint();
-		paint.setStrokeWidth(5);
-		paint.setColor(color);	
-		canvas.drawPoint(X, Y, paint);
-		return posY+15;
-	}
+    // Debug text paint stuff
+    private Paint mTextPaint;
+    private TextPaint mTextPaintShadow;
 
-	/**
-	 * Draw a text with a nice shadow
-	 */
-	public static void drawTextShadowed(Canvas canvas, String text, float x, float y, Paint textPain, Paint shadowPaint) {
-    	canvas.drawText(text, x-1, y, shadowPaint);
-    	canvas.drawText(text, x, y+1, shadowPaint);
-    	canvas.drawText(text, x+1, y, shadowPaint);
-    	canvas.drawText(text, x, y-1, shadowPaint);    	
-    	canvas.drawText(text, x, y, textPain);
+    /** Px / Draw call */
+    private int mCurlSpeed;
+
+    /** Fixed update time used to create a smooth curl animation */
+    //private int mUpdateRate;
+
+    /** The initial offset for x and y axis movements */
+    private int mInitialEdgeOffset;
+
+    /** Maximum radius a page can be flipped, by default it's the width of the view */
+    private float mFlipRadius;
+
+    /** Point used to move */
+    private Vector2D mMovement;
+
+    /** Movement point form the last frame */
+    private Vector2D mOldMovement;
+
+    /** Page curl edge */
+    private Paint mCurlEdgePaint;
+
+    /** Our points used to define the current clipping paths in our draw call */
+    private Vector2D mA, mB, mC, mD, mE, mF, mOrigin;
+
+    /** If false no draw call has been done */
+    private boolean bViewDrawn;
+
+    /** Defines the flip direction that is currently considered */
+    private boolean bFlipRight;
+
+    /** LAGACY The current foreground */
+    private Bitmap mForeground;
+
+    /** LAGACY The current background */
+    private Bitmap mBackground;
+
+    private int backgroundColor = Color.WHITE;
+    private int edgeColor = Color.BLACK;
+
+    private boolean started = false;
+    private boolean finished = false;
+
+    private boolean drawDebugEnabled = false;
+
+    public PageCurlAnimator(boolean flipRight) {
+        this.bFlipRight = flipRight;
+        //this.drawDebugEnabled = true;
+        init();
     }
 
-	
-	public void setForegroundBitmap(Bitmap bitmap ) {
-		this.mForeground = bitmap;
-	}
-	
-	public void setBackgroundBitmap(Bitmap bitmap) {
-		this.mBackground = bitmap;
-	}
-	
-	private int getWidth() {
-		if ( mBackground != null ) {
-			return mBackground.getWidth();
-		}
-		
-		return 0;
-	}
-	
-	private int getHeight() {
-		if ( mBackground != null ) {
-			return mBackground.getHeight();
-		}
-		
-		return 0;
-	}
-	
-	@Override
-	public void draw(Canvas canvas) {			
-				
-		// We need to initialize all size data when we first draw the view
-		if ( !bViewDrawn ) {
-			bViewDrawn = true;
-			onFirstDrawEvent(canvas);
-		}
-		
-		canvas.drawColor(backgroundColor);		
-		
-		// TODO: This just scales the views to the current
-		// width and height. We should add some logic for:
-		//  1) Maintain aspect ratio
-		//  2) Uniform scale
-		//  3) ...
-		Rect rect = new Rect();
-		rect.left = 0;
-		rect.top = 0;
-		rect.bottom = getHeight();
-		rect.right = getWidth();
-		
-		// First Page render
-		Paint paint = new Paint();
-		
-	
-		// Draw our elements
-		try {
-			drawForeground(canvas, rect, paint);
-		} catch (Exception e ) {
-			//ErrorReporter.getInstance().handleException(e);
-		}
-		
-		try {
-			drawBackground(canvas, rect, paint);
-		} catch (Exception e) {
-			//ErrorReporter.getInstance().handleException(e);
-		}		
-		
-		drawCurlEdge(canvas);
-		
-		if ( this.drawDebugEnabled  ) {
-			drawDebug(canvas);
-		}
-		
-	}
-	
-	/**
-	 * Initialize the view
-	 */
-	private final void init() {		
-		
-		// Foreground text paint
-		mTextPaint = new Paint();
-		mTextPaint.setAntiAlias(true);
-		mTextPaint.setTextSize(16);
-		mTextPaint.setColor(0xFF000000);
-		
-		// The shadow
-		mTextPaintShadow = new TextPaint();
-		mTextPaintShadow.setAntiAlias(true);
-		mTextPaintShadow.setTextSize(16);
-		mTextPaintShadow.setColor(0x00000000);
-		
-		// Base padding
-		//setPadding(3, 3, 3, 3);
-		
-		mMovement =  new Vector2D(0,0);
-		
-		mOldMovement = new Vector2D(0,0);				
-		
-		// Create our edge paint
-		mCurlEdgePaint = new Paint();		
-		mCurlEdgePaint.setAntiAlias(true);
-		mCurlEdgePaint.setStyle(Paint.Style.STROKE);
-	//	mCurlEdgePaint.setColor(this.edgeColor);
-		
-	//	mCurlEdgePaint.setShadowLayer(10, -5, 5, 0x99000000);
-		
-		
-		// Set the default props, those come from an XML :D
-		mCurlSpeed = 30;		
-		mInitialEdgeOffset = 20;
-		
-	}
-	
-	/**
-	 * Reset points to it's initial clip edge state
-	 */
-	public void ResetClipEdge()
-	{
-		// Set our base movement
-		mMovement.x = mInitialEdgeOffset;
-		mMovement.y = mInitialEdgeOffset;		
-		mOldMovement.x = 0;
-		mOldMovement.y = 0;		
-		
-		if ( ! bFlipRight ) {
-			mMovement.x = getWidth();
-			mMovement.y = mInitialEdgeOffset;
-		}
-		
-		// Now set the points
-		// TODO: OK, those points MUST come from our measures and
-		// the actual bounds of the view!
-		mA = new Vector2D(mInitialEdgeOffset, 0);
-		mB = new Vector2D(this.getWidth(), this.getHeight());
-		mC = new Vector2D(this.getWidth(), 0);
-		mD = new Vector2D(0, 0);
-		mE = new Vector2D(0, 0);
-		mF = new Vector2D(0, 0);		
-				
-		// The movement origin point
-		mOrigin = new Vector2D(this.getWidth(), 0);
-	}	
-	
-	/**
-	 * Set the curl speed.
-	 * @param curlSpeed - New speed in px/frame
-	 * @throws IllegalArgumentException if curlspeed < 1
-	 */
-	public void SetCurlSpeed(int curlSpeed)
-	{
-		if ( curlSpeed < 1 )
-			throw new IllegalArgumentException("curlSpeed must be greated than 0");
-		mCurlSpeed = curlSpeed;
-	}
-	
-	/**
-	 * Get the current curl speed
-	 * @return int - Curl speed in px/frame
-	 */
-	public int GetCurlSpeed()
-	{
-		return mCurlSpeed;
-	}	
-	
-	/**
-	 * Set the initial pixel offset for the curl edge
-	 * @param initialEdgeOffset - px offset for curl edge
-	 * @throws IllegalArgumentException if initialEdgeOffset < 0
-	 */
-	public void SetInitialEdgeOffset(int initialEdgeOffset)
-	{
-		if ( initialEdgeOffset < 0 )
-			throw new IllegalArgumentException("initialEdgeOffset can not negative");
-		mInitialEdgeOffset = initialEdgeOffset;
-	}
-	
-	/**
-	 * Get the initial pixel offset for the curl edge
-	 * @return int - px
-	 */
-	public int GetInitialEdgeOffset()
-	{
-		return mInitialEdgeOffset;
-	}
-	
-	/**
-	 * Make sure we never move too much, and make sure that if we 
-	 * move too much to add a displacement so that the movement will 
-	 * be still in our radius.
-	 * @param radius - radius form the flip origin
-	 * @param bMaintainMoveDir - Cap movement but do not change the
-	 * current movement direction
-	 * @return Corrected point
-	 */
-	private Vector2D CapMovement(Vector2D point, boolean bMaintainMoveDir)
-	{
-		// Make sure we never ever move too much
-		if (point.distance(mOrigin) > mFlipRadius)
-		{
-			if ( bMaintainMoveDir )
-			{
-				// Maintain the direction
-				point = mOrigin.sum(point.sub(mOrigin).normalize().mult(mFlipRadius));
-			}
-			else
-			{
-				// Change direction
-				if ( point.x > (mOrigin.x+mFlipRadius))
-					point.x = (mOrigin.x+mFlipRadius);
-				else if ( point.x < (mOrigin.x-mFlipRadius) )
-					point.x = (mOrigin.x-mFlipRadius);
-				point.y = (float) (Math.sin(Math.acos(Math.abs(point.x-mOrigin.x)/mFlipRadius))*mFlipRadius);
-			}
-		}
-		return point;
-	}
-	
-	/**
-	 * Do a simple page curl effect
-	 */
-	private void doSimpleCurl() {
-		int width = getWidth();
-		int height = getHeight();
-		
-		// Calculate point A
-		mA.x = width - mMovement.x;
-		mA.y = height;
+    public void setDrawDebugEnabled(boolean drawDebugEnabled) {
+        this.drawDebugEnabled = drawDebugEnabled;
+    }
 
-		// Calculate point D
-		mD.x = 0;
-		mD.y = 0;
-		if (mA.x > width / 2) {
-			mD.x = width;
-			mD.y = height - (width - mA.x) * height / mA.x;
-		} else {
-			mD.x = 2 * mA.x;
-			mD.y = 0;
-		}
-		
-		// Now calculate E and F taking into account that the line
-		// AD is perpendicular to FB and EC. B and C are fixed points.
-		double angle = Math.atan((height - mD.y) / (mD.x + mMovement.x - width));
-		double _cos = Math.cos(2 * angle);
-		double _sin = Math.sin(2 * angle);
+    @Override
+    public synchronized void advanceOneFrame() {
 
-		// And get F
-		mF.x = (float) (width - mMovement.x + _cos * mMovement.x);
-		mF.y = (float) (height - _sin * mMovement.x);
-		
-		// If the x position of A is above half of the page we are still not
-		// folding the upper-right edge and so E and D are equal.
-		if (mA.x > width / 2) {
-			mE.x = mD.x;
-			mE.y = mD.y;
-		}
-		else
-		{
-			// So get E
-			mE.x = (float) (mD.x + _cos * (width - mD.x));
-			mE.y = (float) -(_sin * (width - mD.x));
-		}
-	}
+        started = true;
 
-	
-	/**
-	 * Called on the first draw event of the view
-	 * @param canvas
-	 */
-	protected void onFirstDrawEvent(Canvas canvas) {
-		
-		mFlipRadius = getWidth();
-		
-		ResetClipEdge();
-		doSimpleCurl();
-	}
-	
-	/**
-	 * Draw the foreground
-	 * @param canvas
-	 * @param rect
-	 * @param paint
-	 */
-	private void drawForeground( Canvas canvas, Rect rect, Paint paint ) {		
-		if ( ! finished || !bFlipRight ) {
-			if ( ! mForeground.isRecycled() ) {
-				canvas.drawBitmap(mForeground, null, rect, null);
-			}
-		}
-	}
-	
-	/**
-	 * Create a Path used as a mask to draw the background page
-	 * @return
-	 */
-	private Path createBackgroundPath() {
-		Path path = new Path();
-		path.moveTo(mA.x, mA.y);
-		path.lineTo(mB.x, mB.y);
-		path.lineTo(mC.x, mC.y);
-		path.lineTo(mD.x, mD.y);
-		path.lineTo(mA.x, mA.y);
-		return path;
-	}
-	
-	/**
-	 * Draw the background image.
-	 * @param canvas
-	 * @param rect
-	 * @param paint
-	 */
-	private void drawBackground( Canvas canvas, Rect rect, Paint paint ) {
-		
-		if ( ! finished ) {
-			Path mask = createBackgroundPath();
+        if ( finished || mOrigin == null ) {
+            return;
+        }
 
-			// Save current canvas so we do not mess it up
-			canvas.save();
-			canvas.clipPath(mask);						
-		}
-		
-		if ( ! (finished && !bFlipRight) ) { 
-			
-			if ( ! mBackground.isRecycled() ) {
-				canvas.drawBitmap(mBackground, null, rect, paint);
-			}
-			
-			canvas.restore();
-		}
-		
-	}
-	
-	/**
-	 * Creates a path used to draw the curl edge in.
-	 * @return
-	 */
-	private Path createCurlEdgePath() {
-		Path path = new Path();
-		path.moveTo(mA.x, mA.y);
-		path.lineTo(mD.x, mD.y);
-		path.lineTo(mE.x, mE.y);
-		path.lineTo(mF.x, mF.y);
-		path.lineTo(mA.x, mA.y);
-		return path;
-	}
-	
-	/**
-	 * Draw the curl page edge
-	 * @param canvas
-	 */
-	private void drawCurlEdge( Canvas canvas )
-	{
-		if ( started && ! finished ) {
-			
-			Path path = createCurlEdgePath();
-			
-			mCurlEdgePaint.setColor(backgroundColor);
-			mCurlEdgePaint.setStyle(Style.FILL);
-			mCurlEdgePaint.setShadowLayer(10, -5, 5, edgeColor );
-			
-			canvas.drawPath(path, mCurlEdgePaint);
-			
-			mCurlEdgePaint.setColor(edgeColor);
-			mCurlEdgePaint.setStyle(Style.STROKE);
-			mCurlEdgePaint.setShadowLayer(0, 0, 0, edgeColor );
-			
-			canvas.drawPath(path, mCurlEdgePaint);
-			
-		}
-	}	
-	
-	@Override
-	public int getAnimationSpeed() {
-		return 30;
-	}
-	
-	@Override
-	public boolean isFinished() {
-		return finished;
-	}
-	
-	/**
-	 * Inner class used to represent a 2D point.
-	 */
-	private class Vector2D
-	{
-		public float x,y;
-		public Vector2D(float x, float y)
-		{
-			this.x = x;
-			this.y = y;
-		}
-		
-		@Override
-		public String toString() {
-			// TODO Auto-generated method stub
-			return "("+this.x+","+this.y+")";
-		}
-		
-		public boolean equals(Object o) {
-			if (o instanceof Vector2D) {
-				Vector2D p = (Vector2D) o;
-				return p.x == x && p.y == y;
-	        }
-	        return false;
-		}
-		
-		public Vector2D sum(Vector2D b) {
+        int width = getWidth();
+
+        // Handle speed
+        float curlSpeed = mCurlSpeed;
+        if ( !bFlipRight ) {
+            curlSpeed *= -1;
+        }
+
+        // Move us
+        mMovement.x += curlSpeed;
+        mMovement = CapMovement(mMovement, false);
+
+        // Create values
+        doSimpleCurl();
+
+        // Check for endings :D
+        if (mA.x < 1 || mA.x > width - 1) {
+            finished = true;
+
+            ResetClipEdge();
+
+            // Create values
+            doSimpleCurl();
+        }
+    }
+
+    public void setBackgroundColor(int backgroundColor) {
+        this.backgroundColor = backgroundColor;
+    }
+
+    public void setEdgeColor( int edgeColor ) {
+        this.edgeColor = edgeColor;
+    }
+
+    private void drawDebug(Canvas canvas)
+    {
+        float posX = 10;
+        float posY = 20;
+
+        Paint paint = new Paint();
+        paint.setStrokeWidth(5);
+        paint.setStyle(Style.FILL);
+
+        paint.setColor(Color.BLACK);
+
+        canvas.drawCircle(mOrigin.x, mOrigin.y, getWidth(), paint);
+
+        paint.setStrokeWidth(3);
+        paint.setColor(Color.RED);
+        canvas.drawCircle(mOrigin.x, mOrigin.y, getWidth(), paint);
+
+        paint.setStrokeWidth(5);
+        paint.setColor(Color.BLACK);
+        canvas.drawLine(mOrigin.x, mOrigin.y, mMovement.x, mMovement.y, paint);
+
+        paint.setStrokeWidth(3);
+        paint.setColor(Color.RED);
+        canvas.drawLine(mOrigin.x, mOrigin.y, mMovement.x, mMovement.y, paint);
+
+        posY = debugDrawPoint(canvas,"A",mA,Color.RED,posX,posY);
+        posY = debugDrawPoint(canvas,"B",mB,Color.GREEN,posX,posY);
+        posY = debugDrawPoint(canvas,"C",mC,Color.BLUE,posX,posY);
+        posY = debugDrawPoint(canvas,"D",mD,Color.CYAN,posX,posY);
+        posY = debugDrawPoint(canvas,"E",mE,Color.YELLOW,posX,posY);
+        posY = debugDrawPoint(canvas,"F",mF,Color.LTGRAY,posX,posY);
+        posY = debugDrawPoint(canvas,"Mov",mMovement,Color.DKGRAY,posX,posY);
+        posY = debugDrawPoint(canvas,"Origin",mOrigin,Color.MAGENTA,posX,posY);
+
+        /**/
+    }
+
+    private float debugDrawPoint(Canvas canvas, String name, Vector2D point, int color, float posX, float posY) {
+        return debugDrawPoint(canvas,name+" "+point.toString(),point.x, point.y, color, posX, posY);
+    }
+
+    private float debugDrawPoint(Canvas canvas, String name, float X, float Y, int color, float posX, float posY) {
+        mTextPaint.setColor(color);
+        drawTextShadowed(canvas,name,posX , posY, mTextPaint,mTextPaintShadow);
+        Paint paint = new Paint();
+        paint.setStrokeWidth(5);
+        paint.setColor(color);
+        canvas.drawPoint(X, Y, paint);
+        return posY+15;
+    }
+
+    /**
+     * Draw a text with a nice shadow
+     */
+    public static void drawTextShadowed(Canvas canvas, String text, float x, float y, Paint textPain, Paint shadowPaint) {
+        canvas.drawText(text, x-1, y, shadowPaint);
+        canvas.drawText(text, x, y+1, shadowPaint);
+        canvas.drawText(text, x+1, y, shadowPaint);
+        canvas.drawText(text, x, y-1, shadowPaint);
+        canvas.drawText(text, x, y, textPain);
+    }
+
+
+    public void setForegroundBitmap(Bitmap bitmap ) {
+        this.mForeground = bitmap;
+    }
+
+    public void setBackgroundBitmap(Bitmap bitmap) {
+        this.mBackground = bitmap;
+    }
+
+    private int getWidth() {
+        if ( mBackground != null ) {
+            return mBackground.getWidth();
+        }
+
+        return 0;
+    }
+
+    private int getHeight() {
+        if ( mBackground != null ) {
+            return mBackground.getHeight();
+        }
+
+        return 0;
+    }
+
+    @Override
+    public void draw(Canvas canvas) {
+
+        // We need to initialize all size data when we first draw the view
+        if ( !bViewDrawn ) {
+            bViewDrawn = true;
+            onFirstDrawEvent(canvas);
+        }
+
+        canvas.drawColor(backgroundColor);
+
+        // TODO: This just scales the views to the current
+        // width and height. We should add some logic for:
+        //  1) Maintain aspect ratio
+        //  2) Uniform scale
+        //  3) ...
+        Rect rect = new Rect();
+        rect.left = 0;
+        rect.top = 0;
+        rect.bottom = getHeight();
+        rect.right = getWidth();
+
+        // First Page render
+        Paint paint = new Paint();
+
+
+        // Draw our elements
+        try {
+            drawForeground(canvas, rect, paint);
+        } catch (Exception e ) {
+            //ErrorReporter.getInstance().handleException(e);
+        }
+
+        try {
+            drawBackground(canvas, rect, paint);
+        } catch (Exception e) {
+            //ErrorReporter.getInstance().handleException(e);
+        }
+
+        drawCurlEdge(canvas);
+
+        if ( this.drawDebugEnabled  ) {
+            drawDebug(canvas);
+        }
+
+    }
+
+    /**
+     * Initialize the view
+     */
+    private final void init() {
+
+        // Foreground text paint
+        mTextPaint = new Paint();
+        mTextPaint.setAntiAlias(true);
+        mTextPaint.setTextSize(16);
+        mTextPaint.setColor(0xFF000000);
+
+        // The shadow
+        mTextPaintShadow = new TextPaint();
+        mTextPaintShadow.setAntiAlias(true);
+        mTextPaintShadow.setTextSize(16);
+        mTextPaintShadow.setColor(0x00000000);
+
+        // Base padding
+        //setPadding(3, 3, 3, 3);
+
+        mMovement =  new Vector2D(0,0);
+
+        mOldMovement = new Vector2D(0,0);
+
+        // Create our edge paint
+        mCurlEdgePaint = new Paint();
+        mCurlEdgePaint.setAntiAlias(true);
+        mCurlEdgePaint.setStyle(Paint.Style.STROKE);
+        //      mCurlEdgePaint.setColor(this.edgeColor);
+
+        //      mCurlEdgePaint.setShadowLayer(10, -5, 5, 0x99000000);
+
+
+        // Set the default props, those come from an XML :D
+        mCurlSpeed = 30;
+        mInitialEdgeOffset = 20;
+
+    }
+
+    /**
+     * Reset points to it's initial clip edge state
+     */
+    public void ResetClipEdge()
+    {
+        // Set our base movement
+        mMovement.x = mInitialEdgeOffset;
+        mMovement.y = mInitialEdgeOffset;
+        mOldMovement.x = 0;
+        mOldMovement.y = 0;
+
+        if ( ! bFlipRight ) {
+            mMovement.x = getWidth();
+            mMovement.y = mInitialEdgeOffset;
+        }
+
+        // Now set the points
+        // TODO: OK, those points MUST come from our measures and
+        // the actual bounds of the view!
+        mA = new Vector2D(mInitialEdgeOffset, 0);
+        mB = new Vector2D(this.getWidth(), this.getHeight());
+        mC = new Vector2D(this.getWidth(), 0);
+        mD = new Vector2D(0, 0);
+        mE = new Vector2D(0, 0);
+        mF = new Vector2D(0, 0);
+
+        // The movement origin point
+        mOrigin = new Vector2D(this.getWidth(), 0);
+    }
+
+    /**
+     * Set the curl speed.
+     * @param curlSpeed - New speed in px/frame
+     * @throws IllegalArgumentException if curlspeed < 1
+     */
+    public void SetCurlSpeed(int curlSpeed)
+    {
+        if ( curlSpeed < 1 )
+            throw new IllegalArgumentException("curlSpeed must be greated than 0");
+        mCurlSpeed = curlSpeed;
+    }
+
+    /**
+     * Get the current curl speed
+     * @return int - Curl speed in px/frame
+     */
+    public int GetCurlSpeed()
+    {
+        return mCurlSpeed;
+    }
+
+    /**
+     * Set the initial pixel offset for the curl edge
+     * @param initialEdgeOffset - px offset for curl edge
+     * @throws IllegalArgumentException if initialEdgeOffset < 0
+     */
+    public void SetInitialEdgeOffset(int initialEdgeOffset)
+    {
+        if ( initialEdgeOffset < 0 )
+            throw new IllegalArgumentException("initialEdgeOffset can not negative");
+        mInitialEdgeOffset = initialEdgeOffset;
+    }
+
+    /**
+     * Get the initial pixel offset for the curl edge
+     * @return int - px
+     */
+    public int GetInitialEdgeOffset()
+    {
+        return mInitialEdgeOffset;
+    }
+
+    /**
+     * Make sure we never move too much, and make sure that if we
+     * move too much to add a displacement so that the movement will
+     * be still in our radius.
+     * @param radius - radius form the flip origin
+     * @param bMaintainMoveDir - Cap movement but do not change the
+     * current movement direction
+     * @return Corrected point
+     */
+    private Vector2D CapMovement(Vector2D point, boolean bMaintainMoveDir)
+    {
+        // Make sure we never ever move too much
+        if (point.distance(mOrigin) > mFlipRadius)
+            {
+                if ( bMaintainMoveDir )
+                    {
+                        // Maintain the direction
+                        point = mOrigin.sum(point.sub(mOrigin).normalize().mult(mFlipRadius));
+                    }
+                else
+                    {
+                        // Change direction
+                        if ( point.x > (mOrigin.x+mFlipRadius))
+                            point.x = (mOrigin.x+mFlipRadius);
+                        else if ( point.x < (mOrigin.x-mFlipRadius) )
+                            point.x = (mOrigin.x-mFlipRadius);
+                        point.y = (float) (Math.sin(Math.acos(Math.abs(point.x-mOrigin.x)/mFlipRadius))*mFlipRadius);
+                    }
+            }
+        return point;
+    }
+
+    /**
+     * Do a simple page curl effect
+     */
+    private void doSimpleCurl() {
+        int width = getWidth();
+        int height = getHeight();
+
+        // Calculate point A
+        mA.x = width - mMovement.x;
+        mA.y = height;
+
+        // Calculate point D
+        mD.x = 0;
+        mD.y = 0;
+        if (mA.x > width / 2) {
+            mD.x = width;
+            mD.y = height - (width - mA.x) * height / mA.x;
+        } else {
+            mD.x = 2 * mA.x;
+            mD.y = 0;
+        }
+
+        // Now calculate E and F taking into account that the line
+        // AD is perpendicular to FB and EC. B and C are fixed points.
+        double angle = Math.atan((height - mD.y) / (mD.x + mMovement.x - width));
+        double _cos = Math.cos(2 * angle);
+        double _sin = Math.sin(2 * angle);
+
+        // And get F
+        mF.x = (float) (width - mMovement.x + _cos * mMovement.x);
+        mF.y = (float) (height - _sin * mMovement.x);
+
+        // If the x position of A is above half of the page we are still not
+        // folding the upper-right edge and so E and D are equal.
+        if (mA.x > width / 2) {
+            mE.x = mD.x;
+            mE.y = mD.y;
+        }
+        else
+            {
+                // So get E
+                mE.x = (float) (mD.x + _cos * (width - mD.x));
+                mE.y = (float) -(_sin * (width - mD.x));
+            }
+    }
+
+
+    /**
+     * Called on the first draw event of the view
+     * @param canvas
+     */
+    protected void onFirstDrawEvent(Canvas canvas) {
+
+        mFlipRadius = getWidth();
+
+        ResetClipEdge();
+        doSimpleCurl();
+    }
+
+    /**
+     * Draw the foreground
+     * @param canvas
+     * @param rect
+     * @param paint
+     */
+    private void drawForeground( Canvas canvas, Rect rect, Paint paint ) {
+        if ( ! finished || !bFlipRight ) {
+            if ( ! mForeground.isRecycled() ) {
+                canvas.drawBitmap(mForeground, null, rect, null);
+            }
+        }
+    }
+
+    /**
+     * Create a Path used as a mask to draw the background page
+     * @return
+     */
+    private Path createBackgroundPath() {
+        Path path = new Path();
+        path.moveTo(mA.x, mA.y);
+        path.lineTo(mB.x, mB.y);
+        path.lineTo(mC.x, mC.y);
+        path.lineTo(mD.x, mD.y);
+        path.lineTo(mA.x, mA.y);
+        return path;
+    }
+
+    /**
+     * Draw the background image.
+     * @param canvas
+     * @param rect
+     * @param paint
+     */
+    private void drawBackground( Canvas canvas, Rect rect, Paint paint ) {
+
+        if ( ! finished ) {
+            Path mask = createBackgroundPath();
+
+            // Save current canvas so we do not mess it up
+            canvas.save();
+            canvas.clipPath(mask);
+        }
+
+        if ( ! (finished && !bFlipRight) ) {
+
+            if ( ! mBackground.isRecycled() ) {
+                canvas.drawBitmap(mBackground, null, rect, paint);
+            }
+
+            canvas.restore();
+        }
+
+    }
+
+    /**
+     * Creates a path used to draw the curl edge in.
+     * @return
+     */
+    private Path createCurlEdgePath() {
+        Path path = new Path();
+        path.moveTo(mA.x, mA.y);
+        path.lineTo(mD.x, mD.y);
+        path.lineTo(mE.x, mE.y);
+        path.lineTo(mF.x, mF.y);
+        path.lineTo(mA.x, mA.y);
+        return path;
+    }
+
+    /**
+     * Draw the curl page edge
+     * @param canvas
+     */
+    private void drawCurlEdge( Canvas canvas )
+    {
+        if ( started && ! finished ) {
+
+            Path path = createCurlEdgePath();
+
+            mCurlEdgePaint.setColor(backgroundColor);
+            mCurlEdgePaint.setStyle(Style.FILL);
+            mCurlEdgePaint.setShadowLayer(10, -5, 5, edgeColor );
+
+            canvas.drawPath(path, mCurlEdgePaint);
+
+            mCurlEdgePaint.setColor(edgeColor);
+            mCurlEdgePaint.setStyle(Style.STROKE);
+            mCurlEdgePaint.setShadowLayer(0, 0, 0, edgeColor );
+
+            canvas.drawPath(path, mCurlEdgePaint);
+
+        }
+    }
+
+    @Override
+    public int getAnimationSpeed() {
+        return 30;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return finished;
+    }
+
+    /**
+     * Inner class used to represent a 2D point.
+     */
+    private class Vector2D
+    {
+        public float x,y;
+        public Vector2D(float x, float y)
+        {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public String toString() {
+            // TODO Auto-generated method stub
+            return "("+this.x+","+this.y+")";
+        }
+
+        public boolean equals(Object o) {
+            if (o instanceof Vector2D) {
+                Vector2D p = (Vector2D) o;
+                return p.x == x && p.y == y;
+            }
+            return false;
+        }
+
+        public Vector2D sum(Vector2D b) {
             return new Vector2D(x+b.x,y+b.y);
-		}
-		
-		public Vector2D sub(Vector2D b) {
+        }
+
+        public Vector2D sub(Vector2D b) {
             return new Vector2D(x-b.x,y-b.y);
-		}  
-	    public float distanceSquared(Vector2D other) {    	
-	    	
-	    	float dx = other.x - x;
-	    	float dy = other.y - y;
+        }
+        public float distanceSquared(Vector2D other) {
+
+            float dx = other.x - x;
+            float dy = other.y - y;
 
             return (dx * dx) + (dy * dy);
-	    }
-	
-	    public float distance(Vector2D other) {
-	            return (float) Math.sqrt(distanceSquared(other));
-	    }
-	    
-	    public float dotProduct(Vector2D other) {
+        }
+
+        public float distance(Vector2D other) {
+            return (float) Math.sqrt(distanceSquared(other));
+        }
+
+        public float dotProduct(Vector2D other) {
             return other.x * x + other.y * y;
-	    }
-		
-		public Vector2D normalize() {
-			float magnitude = (float) Math.sqrt(dotProduct(this));
+        }
+
+        public Vector2D normalize() {
+            float magnitude = (float) Math.sqrt(dotProduct(this));
             return new Vector2D(x / magnitude, y / magnitude);
-		}
-		
-		public Vector2D mult(float scalar) {
-	            return new Vector2D(x*scalar,y*scalar);
-	    }
-	}
-	
-	@Override
-	public void stop() {
-		this.finished = true;		
-	}
-	
+        }
+
+        public Vector2D mult(float scalar) {
+            return new Vector2D(x*scalar,y*scalar);
+        }
+    }
+
+    @Override
+    public void stop() {
+        this.finished = true;
+    }
+
 }

--- a/src/net/nightwhistler/pageturner/animation/PageTimer.java
+++ b/src/net/nightwhistler/pageturner/animation/PageTimer.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -22,67 +22,67 @@ import android.graphics.*;
 import android.graphics.Paint.Style;
 
 public class PageTimer implements Animator {
-	
-	private Bitmap backgroundImage;
-	private int bottom;
-	
-	private int speed = 20;
-	
-	private static final int MAX_STEP = 500;
 
-	int count = 0;
-	
-	public PageTimer(Bitmap backgroundImage, int bottom) {
-		this.backgroundImage = backgroundImage;
-		this.bottom = bottom;
-	}
-	
-	@Override
-	public void advanceOneFrame() {
-		count += 1;		
-	}
-	
-	@Override
-	public void draw(Canvas canvas) {
-		Paint paint = new Paint();
-		
-		Rect fullScreen = new Rect(0,0, backgroundImage.getWidth(), backgroundImage.getHeight() );		
-		canvas.drawBitmap(backgroundImage, null, fullScreen, paint);
-		
-		paint.setColor(Color.GRAY);
-		paint.setStyle(Style.STROKE);
-		
-		int timerHeight = 10;
-		Rect timer = new Rect( 0, backgroundImage.getHeight() - (timerHeight + bottom), 
-				backgroundImage.getWidth(), backgroundImage.getHeight() - bottom );
-		canvas.drawRect(timer, paint);
-		
-		float percentage = (float) count / (float) MAX_STEP;
-		int width = (int) (backgroundImage.getWidth() * percentage);
-		
-		timer.right = width;
-		paint.setStyle(Style.FILL);
-		canvas.drawRect(timer, paint);
-	}
-	
-	@Override
-	public void stop() {
-		count = MAX_STEP + 1;		
-	}
-	
-	@Override
-	public int getAnimationSpeed() {
-		return speed;
-	}
-	
-	public void setSpeed(int speed) {
-		this.speed = speed;
-	}
-	
-	@Override
-	public boolean isFinished() {
-		return count >= MAX_STEP;
-	}
-	
-	
+    private Bitmap backgroundImage;
+    private int bottom;
+
+    private int speed = 20;
+
+    private static final int MAX_STEP = 500;
+
+    int count = 0;
+
+    public PageTimer(Bitmap backgroundImage, int bottom) {
+        this.backgroundImage = backgroundImage;
+        this.bottom = bottom;
+    }
+
+    @Override
+    public void advanceOneFrame() {
+        count += 1;
+    }
+
+    @Override
+    public void draw(Canvas canvas) {
+        Paint paint = new Paint();
+
+        Rect fullScreen = new Rect(0,0, backgroundImage.getWidth(), backgroundImage.getHeight() );
+        canvas.drawBitmap(backgroundImage, null, fullScreen, paint);
+
+        paint.setColor(Color.GRAY);
+        paint.setStyle(Style.STROKE);
+
+        int timerHeight = 10;
+        Rect timer = new Rect( 0, backgroundImage.getHeight() - (timerHeight + bottom),
+            backgroundImage.getWidth(), backgroundImage.getHeight() - bottom );
+        canvas.drawRect(timer, paint);
+
+        float percentage = (float) count / (float) MAX_STEP;
+        int width = (int) (backgroundImage.getWidth() * percentage);
+
+        timer.right = width;
+        paint.setStyle(Style.FILL);
+        canvas.drawRect(timer, paint);
+    }
+
+    @Override
+    public void stop() {
+        count = MAX_STEP + 1;
+    }
+
+    @Override
+    public int getAnimationSpeed() {
+        return speed;
+    }
+
+    public void setSpeed(int speed) {
+        this.speed = speed;
+    }
+
+    @Override
+    public boolean isFinished() {
+        return count >= MAX_STEP;
+    }
+
+
 }

--- a/src/net/nightwhistler/pageturner/animation/RollingBlindAnimator.java
+++ b/src/net/nightwhistler/pageturner/animation/RollingBlindAnimator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -22,78 +22,78 @@ import android.graphics.*;
 
 /**
  * Rolling-blind autoscroll Animator.
- * 
+ *
  * Slowly unveils the new page on top of the old one.
- * 
+ *
  * @author Alex Kuiper
  *
  */
 public class RollingBlindAnimator implements Animator {
 
-	private Bitmap backgroundBitmap;
-	private Bitmap foregroundBitmap;
-	
-	private int count;	
-		
-	private int animationSpeed;
-	
-	private static final int MAX_STEPS = 500;
-		
-	@Override
-	public void advanceOneFrame() {
-		count++;		
-	}
-	
-	@Override
-	public void draw(Canvas canvas) {
-		if ( backgroundBitmap != null && foregroundBitmap != null ) {
-			
-			float percentage = (float) count / (float) MAX_STEPS;
-			
-			int pixelsToDraw = (int) (backgroundBitmap.getHeight() * percentage); 	
-			
-			Rect top = new Rect( 0, 0, backgroundBitmap.getWidth(), pixelsToDraw );
-						
-			canvas.drawBitmap(foregroundBitmap, top, top, null);
-			
-			Rect bottom = new Rect( 0, pixelsToDraw, backgroundBitmap.getWidth(), backgroundBitmap.getHeight() );
-			
-			canvas.drawBitmap(backgroundBitmap, bottom, bottom, null);
-			
-			Paint paint = new Paint();
-			paint.setColor(Color.GRAY);
-			paint.setStyle(Paint.Style.STROKE);
-			
-			canvas.drawLine(0, pixelsToDraw, backgroundBitmap.getWidth(), pixelsToDraw, paint);
-		}		
-	}
-	
-	@Override
-	public boolean isFinished() {
-		return backgroundBitmap == null
-			|| count >= MAX_STEPS; 
-	}
-	
-	@Override
-	public void stop() {
-		this.backgroundBitmap = null;		
-	}
-	
-	@Override
-	public int getAnimationSpeed() {
-		return this.animationSpeed;
-	}	
-	
-	public void setBackgroundBitmap(Bitmap backgroundBitmap) {
-		this.backgroundBitmap = backgroundBitmap;
-	}
-	
-	public void setForegroundBitmap(Bitmap foregroundBitmap) {
-		this.foregroundBitmap = foregroundBitmap;
-	}	
-	
-	public void setAnimationSpeed(int animationSpeed) {
-		this.animationSpeed = animationSpeed;
-	}
-	
+    private Bitmap backgroundBitmap;
+    private Bitmap foregroundBitmap;
+
+    private int count;
+
+    private int animationSpeed;
+
+    private static final int MAX_STEPS = 500;
+
+    @Override
+    public void advanceOneFrame() {
+        count++;
+    }
+
+    @Override
+    public void draw(Canvas canvas) {
+        if ( backgroundBitmap != null && foregroundBitmap != null ) {
+
+            float percentage = (float) count / (float) MAX_STEPS;
+
+            int pixelsToDraw = (int) (backgroundBitmap.getHeight() * percentage);
+
+            Rect top = new Rect( 0, 0, backgroundBitmap.getWidth(), pixelsToDraw );
+
+            canvas.drawBitmap(foregroundBitmap, top, top, null);
+
+            Rect bottom = new Rect( 0, pixelsToDraw, backgroundBitmap.getWidth(), backgroundBitmap.getHeight() );
+
+            canvas.drawBitmap(backgroundBitmap, bottom, bottom, null);
+
+            Paint paint = new Paint();
+            paint.setColor(Color.GRAY);
+            paint.setStyle(Paint.Style.STROKE);
+
+            canvas.drawLine(0, pixelsToDraw, backgroundBitmap.getWidth(), pixelsToDraw, paint);
+        }
+    }
+
+    @Override
+    public boolean isFinished() {
+        return backgroundBitmap == null
+            || count >= MAX_STEPS;
+    }
+
+    @Override
+    public void stop() {
+        this.backgroundBitmap = null;
+    }
+
+    @Override
+    public int getAnimationSpeed() {
+        return this.animationSpeed;
+    }
+
+    public void setBackgroundBitmap(Bitmap backgroundBitmap) {
+        this.backgroundBitmap = backgroundBitmap;
+    }
+
+    public void setForegroundBitmap(Bitmap foregroundBitmap) {
+        this.foregroundBitmap = foregroundBitmap;
+    }
+
+    public void setAnimationSpeed(int animationSpeed) {
+        this.animationSpeed = animationSpeed;
+    }
+
 }

--- a/src/net/nightwhistler/pageturner/bookmark/Bookmark.java
+++ b/src/net/nightwhistler/pageturner/bookmark/Bookmark.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013 Alex Kuiper, Rob Hoelz
- * 
+ *
  * This file is part of PageTurner
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/net/nightwhistler/pageturner/bookmark/BookmarkDatabaseHelper.java
+++ b/src/net/nightwhistler/pageturner/bookmark/BookmarkDatabaseHelper.java
@@ -78,7 +78,7 @@ public class BookmarkDatabaseHelper extends SQLiteOpenHelper {
     public void onCreate(SQLiteDatabase db) {
         db.execSQL(getCreateTableString());
         db.execSQL("CREATE UNIQUE INDEX fn_name_index ON " + TABLE_NAME + "(" + Field.file_name + ", "
-                + Field.book_index + ", " + Field.book_position + ");");
+            + Field.book_index + ", " + Field.book_position + ");");
 
 
         for ( int i=0; i < 10000; i++ ) {
@@ -96,13 +96,13 @@ public class BookmarkDatabaseHelper extends SQLiteOpenHelper {
 
     public void deleteBookmark( Bookmark bookmark ) {
         getDataBase().delete( TABLE_NAME,
-                "file_name = ? and book_index = ? and book_position = ?",
-                array(
-                        bookmark.getFileName(),
-                        Integer.toString(bookmark.getIndex()),
-                        Integer.toString(bookmark.getPosition() )
-                )
-        );
+            "file_name = ? and book_index = ? and book_position = ?",
+            array(
+                bookmark.getFileName(),
+                Integer.toString(bookmark.getIndex()),
+                Integer.toString(bookmark.getPosition() )
+                  )
+                              );
     }
 
     @Override
@@ -138,8 +138,8 @@ public class BookmarkDatabaseHelper extends SQLiteOpenHelper {
 
         List<Bookmark> bookmarks = new ArrayList<>();
         Cursor cursor = getDataBase().query(false, TABLE_NAME, null,
-                "file_name = ?", new String[]{fileName}, null, null,
-                "book_index, book_position ASC", null);
+            "file_name = ?", new String[]{fileName}, null, null,
+            "book_index, book_position ASC", null);
 
         int fileNameIndex = cursor.getColumnIndex(Field.file_name.name());
         int nameIndex = cursor.getColumnIndex(Field.name.name());

--- a/src/net/nightwhistler/pageturner/catalog/Catalog.java
+++ b/src/net/nightwhistler/pageturner/catalog/Catalog.java
@@ -47,26 +47,26 @@ import static jedi.functional.FunctionalPrimitives.firstOption;
 import static jedi.functional.FunctionalPrimitives.isEmpty;
 
 public class Catalog {
-	
-	/**
-	 * Reserved ID to identify the feed entry where custom sites are added.
-	 */
-	public static final String CUSTOM_SITES_ID = "IdCustomSites";
-	
+
+    /**
+     * Reserved ID to identify the feed entry where custom sites are added.
+     */
+    public static final String CUSTOM_SITES_ID = "IdCustomSites";
+
     private static final int ABBREV_TEXT_LEN = 150;
 
-	private static final Logger LOG = LoggerFactory.getLogger("Catalog");
-		
-	private Catalog() {}
-	
-	/**
-	 * Selects the right image link for an entry, based on preference.
-	 * 
-	 * @param feed
-	 * @param entry
-	 * @return
-	 */
-	public static Option<Link> getImageLink(Feed feed, Entry entry) {
+    private static final Logger LOG = LoggerFactory.getLogger("Catalog");
+
+    private Catalog() {}
+
+    /**
+     * Selects the right image link for an entry, based on preference.
+     *
+     * @param feed
+     * @param entry
+     * @return
+     */
+    public static Option<Link> getImageLink(Feed feed, Entry entry) {
 
         List<Link> items;
 
@@ -77,44 +77,44 @@ public class Catalog {
         }
 
         return firstOption( items, l -> l != null );
-	}
+    }
 
-	/**
-	 * Loads the details for the given entry into the given layout.
-	 *
-	 * @param layout
-	 * @param entry
-	 * @param abbreviateText
-	 */
-	public static void loadBookDetails(View layout, Entry entry, boolean abbreviateText ) {
-		
-		HtmlSpanner spanner = new HtmlSpanner();
+    /**
+     * Loads the details for the given entry into the given layout.
+     *
+     * @param layout
+     * @param entry
+     * @param abbreviateText
+     */
+    public static void loadBookDetails(View layout, Entry entry, boolean abbreviateText ) {
+
+        HtmlSpanner spanner = new HtmlSpanner();
 
         //We don't want to load images here
         spanner.unregisterHandler( "img" );
-		
-		TextView title = (TextView) layout.findViewById(R.id.itemTitle);
-		TextView desc = (TextView) layout
-				.findViewById(R.id.itemDescription);
 
-		title.setText( entry.getTitle());
+        TextView title = (TextView) layout.findViewById(R.id.itemTitle);
+        TextView desc = (TextView) layout
+            .findViewById(R.id.itemDescription);
 
-		CharSequence text;
-		
-		if (entry.getContent() != null) {
-			text = spanner.fromHtml(entry.getContent().getText());
-		} else if (entry.getSummary() != null) {
-			text = spanner.fromHtml(entry.getSummary());
-		} else {
-			text = "";
-		}
-		
-		if (abbreviateText && text.length() > ABBREV_TEXT_LEN ) {
-			text = text.subSequence(0, ABBREV_TEXT_LEN) + "…";
-		}
-		
-		desc.setText(text);
-	}
+        title.setText( entry.getTitle());
+
+        CharSequence text;
+
+        if (entry.getContent() != null) {
+            text = spanner.fromHtml(entry.getContent().getText());
+        } else if (entry.getSummary() != null) {
+            text = spanner.fromHtml(entry.getSummary());
+        } else {
+            text = "";
+        }
+
+        if (abbreviateText && text.length() > ABBREV_TEXT_LEN ) {
+            text = text.subSequence(0, ABBREV_TEXT_LEN) + "…";
+        }
+
+        desc.setText(text);
+    }
 
 
 }

--- a/src/net/nightwhistler/pageturner/catalog/CatalogListAdapter.java
+++ b/src/net/nightwhistler/pageturner/catalog/CatalogListAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -40,9 +40,9 @@ import static jedi.option.Options.some;
 import static net.nightwhistler.pageturner.catalog.Catalog.getImageLink;
 
 public class CatalogListAdapter extends BaseAdapter {
-	
-	private Feed feed;	
-	private Context context;
+
+    private Feed feed;
+    private Context context;
 
     private Entry loadingEntry = new Entry();
 
@@ -52,10 +52,10 @@ public class CatalogListAdapter extends BaseAdapter {
         Option<Drawable> getThumbnailFor( String baseURL, Link link );
     }
 
-	@Inject
-	public CatalogListAdapter(Context context) {
-		this.context = context;
-	}
+    @Inject
+    public CatalogListAdapter(Context context) {
+        this.context = context;
+    }
 
     public void setImageLoader( CatalogImageLoader imageLoader ) {
         this.imageLoader = imageLoader;
@@ -88,44 +88,44 @@ public class CatalogListAdapter extends BaseAdapter {
         this.notifyDataSetChanged();
     }
 
-	public void setFeed( Feed feed ) {
-		this.feed = feed;
-		this.notifyDataSetChanged();		
-	}
-	
-	public Option<Feed> getFeed() {
-		return option(feed);
-	}
+    public void setFeed( Feed feed ) {
+        this.feed = feed;
+        this.notifyDataSetChanged();
+    }
 
-	@Override
-	public int getCount() {
-		
-		if ( feed == null ) {
-			return 0;
-		}
-		
-		return feed.getEntries().size();
-	}
-	
-	@Override
-	public Option<Entry> getItem(int position) {
+    public Option<Feed> getFeed() {
+        return option(feed);
+    }
+
+    @Override
+    public int getCount() {
+
+        if ( feed == null ) {
+            return 0;
+        }
+
+        return feed.getEntries().size();
+    }
+
+    @Override
+    public Option<Entry> getItem(int position) {
         if ( position >= 0 && position < feed.getEntries().size() ) {
-		    return some(feed.getEntries().get(position));
+            return some(feed.getEntries().get(position));
         }
 
         return none();
-	}
-	
-	@Override
-	public long getItemId(int position) {
-		return position;
-	}
+    }
 
-	
-	@Override
-	public View getView(int position, View convertView, ViewGroup parent) {
-		View rowView;
-		final Option<Entry> entry = getItem(position);
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        View rowView;
+        final Option<Entry> entry = getItem(position);
 
         if ( entry.unsafeGet() == this.loadingEntry ) {
             ProgressBar bar = new ProgressBar(this.context);
@@ -134,7 +134,7 @@ public class CatalogListAdapter extends BaseAdapter {
         }
 
         if ( convertView == null || convertView instanceof  ProgressBar  ) {
-		    LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
             rowView = inflater.inflate(R.layout.catalog_item, parent, false);
         } else {
             rowView = convertView;
@@ -154,10 +154,10 @@ public class CatalogListAdapter extends BaseAdapter {
 
         icon.setImageDrawable( drawableOption.getOrElse(
                 context.getResources().getDrawable(R.drawable.unknown_cover)
-        ));
+                                                        ));
 
-		return rowView;
-	}
+        return rowView;
+    }
 
     private Option<Drawable> getThumbnail( Entry entry ) {
 
@@ -175,5 +175,5 @@ public class CatalogListAdapter extends BaseAdapter {
 
         return this.imageLoader.getThumbnailFor( entry.getBaseURL(), imgLink.unsafeGet() );
     }
-	
+
 }

--- a/src/net/nightwhistler/pageturner/catalog/LoadFeedCallback.java
+++ b/src/net/nightwhistler/pageturner/catalog/LoadFeedCallback.java
@@ -27,13 +27,13 @@ public interface LoadFeedCallback {
 
     public static enum ResultType { REPLACE, APPEND }
 
-	void setNewFeed( Feed feed, ResultType resultType );
+    void setNewFeed( Feed feed, ResultType resultType );
 
-	void errorLoadingFeed( String error );
+    void errorLoadingFeed( String error );
 
     void emptyFeedLoaded(Feed feed);
-		
-	void notifyLinkUpdated(Link link, Drawable drawable);
+
+    void notifyLinkUpdated(Link link, Drawable drawable);
 
     void onLoadingStart();
 

--- a/src/net/nightwhistler/pageturner/dto/HighLight.java
+++ b/src/net/nightwhistler/pageturner/dto/HighLight.java
@@ -106,11 +106,11 @@ public class HighLight {
                 JSONObject json = jsonArray.getJSONObject(i);
 
                 HighLight highLight = new HighLight(
-                        json.getString(Fields.displayText.name()),
-                        json.getInt(Fields.index.name()),
-                        json.getInt(Fields.start.name()),
-                        json.getInt(Fields.end.name()),
-                        json.getInt(Fields.color.name()));
+                    json.getString(Fields.displayText.name()),
+                    json.getInt(Fields.index.name()),
+                    json.getInt(Fields.start.name()),
+                    json.getInt(Fields.end.name()),
+                    json.getInt(Fields.color.name()));
 
                 highLight.setTextNote( json.optString( Fields.textNote.name() ));
 

--- a/src/net/nightwhistler/pageturner/dto/PageOffsets.java
+++ b/src/net/nightwhistler/pageturner/dto/PageOffsets.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -32,11 +32,11 @@ import static jedi.option.Options.option;
 
 /**
  * This class allows page-offsets to be read from and stored as JSON.
- * 
- * Page-offsets are only valid under the circumstances they were 
+ *
+ * Page-offsets are only valid under the circumstances they were
  * calculated with: if text-size, page-margins, etc. change, they
- * must be re-calculated. This class allows checks for this. 
- * 
+ * must be re-calculated. This class allows checks for this.
+ *
  * @author Alex Kuiper
  *
  */
@@ -44,60 +44,60 @@ public class PageOffsets {
 
     public static int ALGORITHM_VERSION = 3;
 
-	private int fontSize;
-	private String fontFamily;
-	
-	private int vMargin;
-	private int hMargin;
-	
-	private int lineSpacing;
-	
-	private boolean fullScreen;
+    private int fontSize;
+    private String fontFamily;
+
+    private int vMargin;
+    private int hMargin;
+
+    private int lineSpacing;
+
+    private boolean fullScreen;
 
     private boolean allowStyling;
 
     private int algorithmVersion;
 
-	private List<List<Integer>> offsets;
-	
-	private static enum Fields { fontSize, fontFamily, vMargin, hMargin, lineSpacing, fullScreen, offsets,
-        allowStyling, algorithmVersion };
-	
-	private PageOffsets() {}
-	
-	public boolean isValid( Configuration config ) {
-		
-		return
-				this.fontFamily.equals( config.getDefaultFontFamily().getName() )
-				&& this.fontSize == config.getTextSize()
-				&& this.vMargin == config.getVerticalMargin()
-				&& this.hMargin == config.getHorizontalMargin()
-				&& this.lineSpacing == config.getLineSpacing()
-				&& this.fullScreen == config.isFullScreenEnabled()
-                && this.allowStyling == config.isAllowStyling()
-                && this.algorithmVersion == ALGORITHM_VERSION;
-	}
-	
-	public List<List<Integer>> getOffsets() {
-		return offsets;
-	}
-	
-	public static PageOffsets fromValues( Configuration config, List<List<Integer>> offsets ) {
-		PageOffsets result = new PageOffsets();
-		result.fontFamily = config.getDefaultFontFamily().getName();
-		result.fontSize = config.getTextSize();
-		result.hMargin = config.getHorizontalMargin();
-		result.vMargin = config.getVerticalMargin();
-		result.lineSpacing = config.getLineSpacing();
-		result.fullScreen = config.isFullScreenEnabled();
+    private List<List<Integer>> offsets;
+
+    private static enum Fields { fontSize, fontFamily, vMargin, hMargin, lineSpacing, fullScreen, offsets,
+                                 allowStyling, algorithmVersion };
+
+    private PageOffsets() {}
+
+    public boolean isValid( Configuration config ) {
+
+        return
+            this.fontFamily.equals( config.getDefaultFontFamily().getName() )
+            && this.fontSize == config.getTextSize()
+            && this.vMargin == config.getVerticalMargin()
+            && this.hMargin == config.getHorizontalMargin()
+            && this.lineSpacing == config.getLineSpacing()
+            && this.fullScreen == config.isFullScreenEnabled()
+            && this.allowStyling == config.isAllowStyling()
+            && this.algorithmVersion == ALGORITHM_VERSION;
+    }
+
+    public List<List<Integer>> getOffsets() {
+        return offsets;
+    }
+
+    public static PageOffsets fromValues( Configuration config, List<List<Integer>> offsets ) {
+        PageOffsets result = new PageOffsets();
+        result.fontFamily = config.getDefaultFontFamily().getName();
+        result.fontSize = config.getTextSize();
+        result.hMargin = config.getHorizontalMargin();
+        result.vMargin = config.getVerticalMargin();
+        result.lineSpacing = config.getLineSpacing();
+        result.fullScreen = config.isFullScreenEnabled();
         result.allowStyling = config.isAllowStyling();
 
         result.algorithmVersion = ALGORITHM_VERSION;
 
-		result.offsets = offsets;
-		
-		return result;
-	}
+        result.offsets = offsets;
+
+        return result;
+    }
 
 
     public static PageOffsets fromJSON( String json ) throws JSONException {
@@ -134,25 +134,25 @@ public class PageOffsets {
 
         return jsonObject.toString();
     }
-	
-	private static List<List<Integer>> readOffsets( JSONArray jsonArray ) throws JSONException {
-		
-		List<List<Integer>> result = new ArrayList<List<Integer>>();
-		
-		for (int i = 0; i < jsonArray.length(); i++) {
-			List<Integer> sublist = new ArrayList<>();
 
-			JSONArray subArray = new JSONArray(jsonArray.getString(i));
+    private static List<List<Integer>> readOffsets( JSONArray jsonArray ) throws JSONException {
 
-			for (int j = 0; j < subArray.length(); j++) {
-				int val = subArray.getInt(j);
-				sublist.add(val);
-			}
+        List<List<Integer>> result = new ArrayList<List<Integer>>();
 
-			result.add(sublist);
-		}
-		
-		return result;
-	}
-	
+        for (int i = 0; i < jsonArray.length(); i++) {
+            List<Integer> sublist = new ArrayList<>();
+
+            JSONArray subArray = new JSONArray(jsonArray.getString(i));
+
+            for (int j = 0; j < subArray.length(); j++) {
+                int val = subArray.getInt(j);
+                sublist.add(val);
+            }
+
+            result.add(sublist);
+        }
+
+        return result;
+    }
+
 }

--- a/src/net/nightwhistler/pageturner/epub/PageTurnerSpine.java
+++ b/src/net/nightwhistler/pageturner/epub/PageTurnerSpine.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -38,71 +38,71 @@ import static jedi.option.Options.some;
 /**
  * Special spine class which handles navigation
  * and provides a custom cover.
- * 
+ *
  * @author Alex Kuiper
  *
  */
 public class PageTurnerSpine implements Iterable<PageTurnerSpine.SpineEntry> {
 
-	private List<SpineEntry> entries;
-	
-	private List<List<Integer>> pageOffsets = new ArrayList<>();
-	
-	private int position;
-	
-	public static final String COVER_HREF = "PageTurnerCover";
-	
-	/** How long should a cover page be to be included **/
-	private static final int COVER_PAGE_THRESHOLD = 1024;
-	
-	private String tocHref;
-	
-	/**
-	 * Creates a new Spine from this book.
-	 * 
-	 * @param book
-	 */
-	public PageTurnerSpine(Book book) {
-		this.entries = new ArrayList<>();
-		this.position = 0;
-		
-		addResource(createCoverResource(book));
-		
-		String href = null;
-	    
-	    if ( entries.size() > 0 && ! entries.get(0).href.equals( COVER_HREF ) ) {
-	    	href = book.getCoverPage().getHref();
-	    } 
-	    
-	    for ( int i=0; i < book.getSpine().size(); i++ ) {
-	    	Resource res = book.getSpine().getResource(i);	      	
-	      	
-	      	if ( href == null || ! (href.equals(res.getHref()))) {
-	      		addResource(res);
-	      	}
-	    }
-	    
-	    if ( book.getNcxResource() != null ) {
-	    	this.tocHref = book.getNcxResource().getHref();
-	    }
-	}
-	
-	public void setPageOffsets(List<List<Integer>> pageOffsets) {
+    private List<SpineEntry> entries;
+
+    private List<List<Integer>> pageOffsets = new ArrayList<>();
+
+    private int position;
+
+    public static final String COVER_HREF = "PageTurnerCover";
+
+    /** How long should a cover page be to be included **/
+    private static final int COVER_PAGE_THRESHOLD = 1024;
+
+    private String tocHref;
+
+    /**
+     * Creates a new Spine from this book.
+     *
+     * @param book
+     */
+    public PageTurnerSpine(Book book) {
+        this.entries = new ArrayList<>();
+        this.position = 0;
+
+        addResource(createCoverResource(book));
+
+        String href = null;
+
+        if ( entries.size() > 0 && ! entries.get(0).href.equals( COVER_HREF ) ) {
+            href = book.getCoverPage().getHref();
+        }
+
+        for ( int i=0; i < book.getSpine().size(); i++ ) {
+            Resource res = book.getSpine().getResource(i);
+
+            if ( href == null || ! (href.equals(res.getHref()))) {
+                addResource(res);
+            }
+        }
+
+        if ( book.getNcxResource() != null ) {
+            this.tocHref = book.getNcxResource().getHref();
+        }
+    }
+
+    public void setPageOffsets(List<List<Integer>> pageOffsets) {
         if ( pageOffsets != null ) {
-		    this.pageOffsets = pageOffsets;
+            this.pageOffsets = pageOffsets;
         } else {
             this.pageOffsets = new ArrayList<>();
         }
-	}
-	
-	public int getTotalNumberOfPages() {
-		int total = 0;
-		for ( List<Integer> pagesPerSection: pageOffsets ) {
-			total += pagesPerSection.size();
-		}
-		
-		return Math.max(0, total - 1);
-	}
+    }
+
+    public int getTotalNumberOfPages() {
+        int total = 0;
+        for ( List<Integer> pagesPerSection: pageOffsets ) {
+            total += pagesPerSection.size();
+        }
+
+        return Math.max(0, total - 1);
+    }
 
     @Override
     public Iterator<SpineEntry> iterator() {
@@ -110,96 +110,96 @@ public class PageTurnerSpine implements Iterable<PageTurnerSpine.SpineEntry> {
     }
 
     public List<List<Integer>> getPageOffsets() {
-		return pageOffsets;
-	}
-	
-	
-	/**
-	 * Adds a new resource.
-	 * @param resource
-	 */
-	private void addResource( Resource resource ) {
-		
-		SpineEntry newEntry = new SpineEntry();
-		newEntry.title = resource.getTitle();
-		newEntry.resource = resource;
-		newEntry.href = resource.getHref();
-		newEntry.size = (int) resource.getSize();
-		
-		entries.add(newEntry);
-	}
-	
-	/**
-	 * Returns the number of entries in this spine.
-	 * This includes the generated cover.
-	 * 
-	 * @return
-	 */
-	public int size() {
-		return this.entries.size();
-	}
-	
-	/**
-	 * Navigates one entry forward.
-	 * 
-	 * @return false if we're already at the end.
-	 */
-	public boolean navigateForward() {
-		
-		if ( this.position == size() -1 ) {
-			return false;
-		}
-		
-		this.position++;
-		return true;				
-	}
-	
-	/**
-	 * Navigates one entry back.
-	 * 
-	 * @return false if we're already at the start
-	 */
-	public boolean navigateBack() {
-		if ( this.position == 0 ) {
-			return false;
-		}
-		
-		this.position--;
-		return true;
-	}
-	
-	/**
-	 * Checks if the current entry is the cover page.
-	 * 
-	 * @return
-	 */
-	public boolean isCover() {
-		return this.position == 0;
-	}
-	
-	/**
-	 * Returns the title of the current entry,
-	 * or null if it could not be determined.
-	 * 
-	 * @return
-	 */
-	public Option<String> getCurrentTitle() {
+        return pageOffsets;
+    }
+
+
+    /**
+     * Adds a new resource.
+     * @param resource
+     */
+    private void addResource( Resource resource ) {
+
+        SpineEntry newEntry = new SpineEntry();
+        newEntry.title = resource.getTitle();
+        newEntry.resource = resource;
+        newEntry.href = resource.getHref();
+        newEntry.size = (int) resource.getSize();
+
+        entries.add(newEntry);
+    }
+
+    /**
+     * Returns the number of entries in this spine.
+     * This includes the generated cover.
+     *
+     * @return
+     */
+    public int size() {
+        return this.entries.size();
+    }
+
+    /**
+     * Navigates one entry forward.
+     *
+     * @return false if we're already at the end.
+     */
+    public boolean navigateForward() {
+
+        if ( this.position == size() -1 ) {
+            return false;
+        }
+
+        this.position++;
+        return true;
+    }
+
+    /**
+     * Navigates one entry back.
+     *
+     * @return false if we're already at the start
+     */
+    public boolean navigateBack() {
+        if ( this.position == 0 ) {
+            return false;
+        }
+
+        this.position--;
+        return true;
+    }
+
+    /**
+     * Checks if the current entry is the cover page.
+     *
+     * @return
+     */
+    public boolean isCover() {
+        return this.position == 0;
+    }
+
+    /**
+     * Returns the title of the current entry,
+     * or null if it could not be determined.
+     *
+     * @return
+     */
+    public Option<String> getCurrentTitle() {
         if ( entries.size() > 0 ) {
             return option(entries.get(position).title);
         } else {
             return none();
         }
-	}
-	
-	/**
-	 * Returns the current resource, or null
-	 * if there is none.
-	 * 
-	 * @return
-	 */
-	public Option<Resource> getCurrentResource() {
-		return getResourceForIndex(position);
-	}
+    }
+
+    /**
+     * Returns the current resource, or null
+     * if there is none.
+     *
+     * @return
+     */
+    public Option<Resource> getCurrentResource() {
+        return getResourceForIndex(position);
+    }
 
     /**
      * Returns the resource after the current one
@@ -208,24 +208,24 @@ public class PageTurnerSpine implements Iterable<PageTurnerSpine.SpineEntry> {
     public Option<Resource> getNextResource() {
         return getResourceForIndex(position + 1);
     }
-	
-	public Option<Resource> getResourceForIndex( int index ) {
-		if ( entries.isEmpty() || index < 0 || index >= entries.size() ) {
-			return none();
-		}
-		
-		return option(entries.get(index).resource);
-	}
-	
-	/**
-	 * Resolves a href relative to the current resource.
-	 * 
-	 * @param href
-	 * @return
-	 */
-	public String resolveHref( String href ) {		
-		
-		Option<Resource> res = getCurrentResource();
+
+    public Option<Resource> getResourceForIndex( int index ) {
+        if ( entries.isEmpty() || index < 0 || index >= entries.size() ) {
+            return none();
+        }
+
+        return option(entries.get(index).resource);
+    }
+
+    /**
+     * Resolves a href relative to the current resource.
+     *
+     * @param href
+     * @return
+     */
+    public String resolveHref( String href ) {
+
+        Option<Resource> res = getCurrentResource();
 
         if (! isEmpty(res) ) {
             Resource actualResource = res.unsafeGet();
@@ -236,35 +236,35 @@ public class PageTurnerSpine implements Iterable<PageTurnerSpine.SpineEntry> {
         }
 
         return href;
-	}
-	
-	/**
-	 * Resolves a HREF relative to the Table of Contents
-	 * 
-	 * @param href
-	 * @return
-	 */
-	public String resolveTocHref( String href ) {
-		if ( this.tocHref != null ) {
-			return resolveHref(href, tocHref);
-		}
-		
-		return href;
-	}
-	
-	private static String resolveHref( String href, String against ) {
-		try {
-			String result = new URI(encode(against)).resolve(encode(href)).getPath();
-			return result;
-		} 
-		catch (URISyntaxException u) {
-			return href;
-		} catch (IllegalArgumentException i) {
+    }
+
+    /**
+     * Resolves a HREF relative to the Table of Contents
+     *
+     * @param href
+     * @return
+     */
+    public String resolveTocHref( String href ) {
+        if ( this.tocHref != null ) {
+            return resolveHref(href, tocHref);
+        }
+
+        return href;
+    }
+
+    private static String resolveHref( String href, String against ) {
+        try {
+            String result = new URI(encode(against)).resolve(encode(href)).getPath();
+            return result;
+        }
+        catch (URISyntaxException u) {
+            return href;
+        } catch (IllegalArgumentException i) {
             return href;
         }
-	}
-	
-	private static String encode(String input) {
+    }
+
+    private static String encode(String input) {
         StringBuilder resultStr = new StringBuilder();
         for (char ch : input.toCharArray()) {
             if ( ch == '\\' ) { //Some books use \ as a separator... invalid, but we'll try to fix it
@@ -285,7 +285,7 @@ public class PageTurnerSpine implements Iterable<PageTurnerSpine.SpineEntry> {
     }
 
     /**
-     * This is slightly unsafe: it lets / and % pass, making 
+     * This is slightly unsafe: it lets / and % pass, making
      * multiple encodes safe.
      * @param ch
      * @return
@@ -296,189 +296,189 @@ public class PageTurnerSpine implements Iterable<PageTurnerSpine.SpineEntry> {
         return " %$&+,:;=?@<>#[]".indexOf(ch) >= 0;
     }
 
-	
-	/**
-	 * Returns the href of the current resource.
-	 * @return
-	 */
-	public Option<String> getCurrentHref() {
-		if ( entries.size() > 0 ) {
+
+    /**
+     * Returns the href of the current resource.
+     * @return
+     */
+    public Option<String> getCurrentHref() {
+        if ( entries.size() > 0 ) {
             return option(entries.get(position).href);
-		} else {
+        } else {
             return none();
         }
-	}
-	
-	/**
-	 * Navigates to a specific point in the spine.
-	 * 
-	 * @param index
-	 * @return false if the point did not exist.
-	 */
-	public boolean navigateByIndex( int index ) {
-		if ( index < 0 || index >= size() ) {
-			return false;
-		}
-		
-		this.position = index;
-		return true;
-	}
-	
-	/**
-	 * Returns the current position in the spine.
-	 * 
-	 * @return
-	 */
-	public int getPosition() {
-		return position;
-	}
-	
-	/**
-	 * Navigates to the point with the given href.
-	 * 
-	 * @param href
-	 * @return false if that point did not exist.
-	 */
-	public boolean navigateByHref( String href ) {
-		
-		String encodedHref = encode(href);
-		
-		for ( int i=0; i < size(); i++ ) {
-			String entryHref = encode(entries.get(i).href);
-			if ( entryHref.equals(encodedHref)){
-				this.position = i;
-				return true;
-			}
-		}
-		
-		return false;
-	}
-	
-	/**
-	 * Returns a percentage, which indicates how
-	 * far the given point in the current entry is
-	 * compared to the whole book.
-	 * 
-	 * @param progressInPart
-	 * @return
-	 */
-	public int getProgressPercentage(double progressInPart) {		
-		return getProgressPercentage(getPosition(), progressInPart);				
-	}
-	
-	private int getProgressPercentage(int index, double progressInPart) {
-		
-		if ( this.entries == null ) {
-			return -1;
-		}
-		
-		double uptoHere = 0;
-		
-		List<Double> percentages = getRelativeSizes();
-		
-		for ( int i=0; i < percentages.size() && i < index; i++ ) {
-			uptoHere += percentages.get( i );
-		}  
-		
-		double thisPart = percentages.get(index);
-		
-		double progress = uptoHere + (progressInPart * thisPart);
-		
-		return (int) (progress * 100);	
-	}
-	
-	/**
-	 * Returns the progress percentage for the given text position 
-	 * in the given index.
-	 * 
-	 * @param index
-	 * @param position
-	 * @return
-	 */
-	public int getProgressPercentage(int index, int position) {
-		if ( this.entries == null || index >= entries.size() ) {
-			return -1;
-		}
-		
-		double progressInPart = ( (double)position / (double) entries.get(index).size);
-		return getProgressPercentage(index, progressInPart);		
-	}
-	
-	
-	
-	/**
-	 * Returns a list of doubles representing the relative size of each spine index.
-	 * @return
-	 */
-	public List<Double> getRelativeSizes() {
-		int total = 0;
-		List<Integer> sizes = new ArrayList<>();
-		
-		for ( int i=0; i < entries.size(); i++ ) {
-			int size = entries.get(i).size;
-			sizes.add(size);
-			total += size;
-		}
-		
-		List<Double> result = new ArrayList<>();
-		for ( int i=0; i < sizes.size(); i++ ) {
-			double part = (double) sizes.get(i) / (double) total;
-			result.add( part );
-		}
-		
-		return result;
-	}
-	
-	private Resource createCoverResource(Book book) {	
-		
-		if ( book.getCoverPage() != null && book.getCoverPage().getSize() > 0
-                && book.getCoverPage().getSize() < COVER_PAGE_THRESHOLD ) {
+    }
+
+    /**
+     * Navigates to a specific point in the spine.
+     *
+     * @param index
+     * @return false if the point did not exist.
+     */
+    public boolean navigateByIndex( int index ) {
+        if ( index < 0 || index >= size() ) {
+            return false;
+        }
+
+        this.position = index;
+        return true;
+    }
+
+    /**
+     * Returns the current position in the spine.
+     *
+     * @return
+     */
+    public int getPosition() {
+        return position;
+    }
+
+    /**
+     * Navigates to the point with the given href.
+     *
+     * @param href
+     * @return false if that point did not exist.
+     */
+    public boolean navigateByHref( String href ) {
+
+        String encodedHref = encode(href);
+
+        for ( int i=0; i < size(); i++ ) {
+            String entryHref = encode(entries.get(i).href);
+            if ( entryHref.equals(encodedHref)){
+                this.position = i;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns a percentage, which indicates how
+     * far the given point in the current entry is
+     * compared to the whole book.
+     *
+     * @param progressInPart
+     * @return
+     */
+    public int getProgressPercentage(double progressInPart) {
+        return getProgressPercentage(getPosition(), progressInPart);
+    }
+
+    private int getProgressPercentage(int index, double progressInPart) {
+
+        if ( this.entries == null ) {
+            return -1;
+        }
+
+        double uptoHere = 0;
+
+        List<Double> percentages = getRelativeSizes();
+
+        for ( int i=0; i < percentages.size() && i < index; i++ ) {
+            uptoHere += percentages.get( i );
+        }
+
+        double thisPart = percentages.get(index);
+
+        double progress = uptoHere + (progressInPart * thisPart);
+
+        return (int) (progress * 100);
+    }
+
+    /**
+     * Returns the progress percentage for the given text position
+     * in the given index.
+     *
+     * @param index
+     * @param position
+     * @return
+     */
+    public int getProgressPercentage(int index, int position) {
+        if ( this.entries == null || index >= entries.size() ) {
+            return -1;
+        }
+
+        double progressInPart = ( (double)position / (double) entries.get(index).size);
+        return getProgressPercentage(index, progressInPart);
+    }
+
+
+
+    /**
+     * Returns a list of doubles representing the relative size of each spine index.
+     * @return
+     */
+    public List<Double> getRelativeSizes() {
+        int total = 0;
+        List<Integer> sizes = new ArrayList<>();
+
+        for ( int i=0; i < entries.size(); i++ ) {
+            int size = entries.get(i).size;
+            sizes.add(size);
+            total += size;
+        }
+
+        List<Double> result = new ArrayList<>();
+        for ( int i=0; i < sizes.size(); i++ ) {
+            double part = (double) sizes.get(i) / (double) total;
+            result.add( part );
+        }
+
+        return result;
+    }
+
+    private Resource createCoverResource(Book book) {
+
+        if ( book.getCoverPage() != null && book.getCoverPage().getSize() > 0
+            && book.getCoverPage().getSize() < COVER_PAGE_THRESHOLD ) {
 
             Log.d("PageTurnerSpine", "Using cover resource " + book.getCoverPage().getHref() );
 
-			return book.getCoverPage();
-		}
+            return book.getCoverPage();
+        }
 
         Log.d("PageTurnerSpine", "Constructing a cover page" );
-		Resource res = new Resource(generateCoverPage(book).getBytes(), COVER_HREF);
-		res.setTitle("Cover");
-		
-		return res;
-	}
-	
-	private String generateCoverPage(Book book) {
-		
-		String centerpiece;
-		
-		//Else we construct a basic front page with title and author.
-		if ( book.getCoverImage() == null ) {												
-			centerpiece = "<center><h1>" + (book.getTitle() != null ? book.getTitle(): "Book without a title") + "</h1>";
-			
-			if ( ! book.getMetadata().getAuthors().isEmpty() ) {						
-				for ( Author author: book.getMetadata().getAuthors() ) {							
-					centerpiece += "<h3>" + author.getFirstname() + " " + author.getLastname() + "</h3>";
-				}
-			} else {
-				centerpiece += "<h3>Unknown author</h3>";
-			}
+        Resource res = new Resource(generateCoverPage(book).getBytes(), COVER_HREF);
+        res.setTitle("Cover");
+
+        return res;
+    }
+
+    private String generateCoverPage(Book book) {
+
+        String centerpiece;
+
+        //Else we construct a basic front page with title and author.
+        if ( book.getCoverImage() == null ) {
+            centerpiece = "<center><h1>" + (book.getTitle() != null ? book.getTitle(): "Book without a title") + "</h1>";
+
+            if ( ! book.getMetadata().getAuthors().isEmpty() ) {
+                for ( Author author: book.getMetadata().getAuthors() ) {
+                    centerpiece += "<h3>" + author.getFirstname() + " " + author.getLastname() + "</h3>";
+                }
+            } else {
+                centerpiece += "<h3>Unknown author</h3>";
+            }
 
             centerpiece += "</center>";
 
-		} else {
-			//If the book has a cover image, we display that
-			centerpiece = "<img src='" + book.getCoverImage().getHref() + "'>";
-		}		
-		
-		return "<html><body>" + centerpiece + "</body></html>";
-	}
-	
-	public class SpineEntry {
-		
-		private String title;
-		private Resource resource;		
-		private String href;
-		
-		private int size;
+        } else {
+            //If the book has a cover image, we display that
+            centerpiece = "<img src='" + book.getCoverImage().getHref() + "'>";
+        }
+
+        return "<html><body>" + centerpiece + "</body></html>";
+    }
+
+    public class SpineEntry {
+
+        private String title;
+        private Resource resource;
+        private String href;
+
+        private int size;
 
         public String getTitle() {
             return title;

--- a/src/net/nightwhistler/pageturner/epub/ResourceLoader.java
+++ b/src/net/nightwhistler/pageturner/epub/ResourceLoader.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -35,47 +35,47 @@ import java.util.zip.ZipFile;
 
 /**
  * This is mostly a performance utility:
- * 
+ *
  * We don't want to load all the images from an
  * EPUB at once, but lazy-loading several images
  * and opening the file for each is too slow.
- * 
+ *
  * The image loader allows a class to register call-backs
  * so several images can be loaded in a single go.
- * 
+ *
  * @author Alex Kuiper
  *
  */
 public class ResourceLoader  {
-	
-	private String fileName;
+
+    private String fileName;
 
     private static final Logger LOG = LoggerFactory.getLogger("ResourceLoader");
 
-	public ResourceLoader(String fileName) {
-		this.fileName = fileName;
-	}
-	
-	public static interface ResourceCallback {
-		void onLoadResource( String href, InputStream stream );
-	}
-	
-	private class Holder {
-		String href;
-		ResourceCallback callback;
-	}
-	
-	private List<Holder> callbacks = new ArrayList<>();
-	
-	public void clear() {
-		this.callbacks.clear();
-	}
-	
-	public void load() throws IOException {
+    public ResourceLoader(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public static interface ResourceCallback {
+        void onLoadResource( String href, InputStream stream );
+    }
+
+    private class Holder {
+        String href;
+        ResourceCallback callback;
+    }
+
+    private List<Holder> callbacks = new ArrayList<>();
+
+    public void clear() {
+        this.callbacks.clear();
+    }
+
+    public void load() throws IOException {
 
         ZipFile zipFile = null;
 
-		try {
+        try {
             zipFile = new ZipFile(this.fileName);
 
             Enumeration<? extends ZipEntry> entries = zipFile.entries();
@@ -83,46 +83,46 @@ public class ResourceLoader  {
             while( entries.hasMoreElements() ) {
                 ZipEntry zipEntry = entries.nextElement();
 
-				if(zipEntry.isDirectory()) {
-					continue;
-				}
+                if(zipEntry.isDirectory()) {
+                    continue;
+                }
 
-				String href = zipEntry.getName();
+                String href = zipEntry.getName();
 
-				List<ResourceCallback> filteredCallbacks = findCallbacksFor(href);
+                List<ResourceCallback> filteredCallbacks = findCallbacksFor(href);
 
-				if ( ! filteredCallbacks.isEmpty() ) {
+                if ( ! filteredCallbacks.isEmpty() ) {
 
-					for ( ResourceCallback callBack: filteredCallbacks ) {
-						callBack.onLoadResource(href, zipFile.getInputStream(zipEntry) );
-					}
-				}
-			}
-		} finally {
-			if ( zipFile != null ) {
-				zipFile.close();
-			}
-			
-			this.callbacks.clear();
-		}
-	}
-	
-	private List<ResourceCallback> findCallbacksFor( String href ) {
-		List<ResourceCallback> result = new ArrayList<>();
+                    for ( ResourceCallback callBack: filteredCallbacks ) {
+                        callBack.onLoadResource(href, zipFile.getInputStream(zipEntry) );
+                    }
+                }
+            }
+        } finally {
+            if ( zipFile != null ) {
+                zipFile.close();
+            }
 
-		for ( Holder holder: this.callbacks ) {
-			if ( href.endsWith(holder.href ) ) {
-				result.add(holder.callback);
-			}
-		}
-		
-		return result;
-	}
-	
-	public void registerCallback( String forHref, ResourceCallback callback )
-            throws AssertionError{
-			
-		Holder holder = new Holder();
+            this.callbacks.clear();
+        }
+    }
+
+    private List<ResourceCallback> findCallbacksFor( String href ) {
+        List<ResourceCallback> result = new ArrayList<>();
+
+        for ( Holder holder: this.callbacks ) {
+            if ( href.endsWith(holder.href ) ) {
+                result.add(holder.callback);
+            }
+        }
+
+        return result;
+    }
+
+    public void registerCallback( String forHref, ResourceCallback callback )
+        throws AssertionError{
+
+        Holder holder = new Holder();
 
         // Default Charset for android is UTF-8
         // http://developer.android.com/reference/java/nio/charset/Charset.html#defaultCharset()
@@ -143,5 +143,5 @@ public class ResourceLoader  {
             // I don't think this will ever be reached
             throw new AssertionError(e);
         }
-	}
+    }
 }

--- a/src/net/nightwhistler/pageturner/epub/SearchTextTask.java
+++ b/src/net/nightwhistler/pageturner/epub/SearchTextTask.java
@@ -43,42 +43,42 @@ import static jedi.option.Options.none;
 import static jedi.option.Options.option;
 
 public class SearchTextTask extends QueueableAsyncTask<String, SearchResult, List<SearchResult>> {
-	
-	private Book book;
-	
-	private HtmlSpanner spanner;
-	
-	public SearchTextTask(Book book) {
-		this.book = book;
-		
-		this.spanner = new HtmlSpanner();
-		
-		DummyHandler dummy = new DummyHandler();
-		
+
+    private Book book;
+
+    private HtmlSpanner spanner;
+
+    public SearchTextTask(Book book) {
+        this.book = book;
+
+        this.spanner = new HtmlSpanner();
+
+        DummyHandler dummy = new DummyHandler();
+
         spanner.registerHandler("img", dummy );
         spanner.registerHandler("image", dummy );
-        
+
         spanner.registerHandler("table", new TableHandler() );
-	}
+    }
 
 
-	@Override
-	public Option<List<SearchResult>> doInBackground(String... params) {
+    @Override
+    public Option<List<SearchResult>> doInBackground(String... params) {
 
-		String searchTerm = params[0];
-		Pattern pattern = Pattern.compile(Pattern.quote((searchTerm)),Pattern.CASE_INSENSITIVE);
+        String searchTerm = params[0];
+        Pattern pattern = Pattern.compile(Pattern.quote((searchTerm)),Pattern.CASE_INSENSITIVE);
 
-		List<SearchResult> result = new ArrayList<>();
+        List<SearchResult> result = new ArrayList<>();
 
-		try {
+        try {
 
-			PageTurnerSpine spine = new PageTurnerSpine(book);
+            PageTurnerSpine spine = new PageTurnerSpine(book);
 
-			for ( int index=0; index < spine.size(); index++ ) {
+            for ( int index=0; index < spine.size(); index++ ) {
 
-				spine.navigateByIndex(index);
+                spine.navigateByIndex(index);
 
-				publishProgress( new SearchResult(null, null, index, 0, 0) );
+                publishProgress( new SearchResult(null, null, index, 0, 0) );
 
                 Option<Resource> currentResource = spine.getCurrentResource();
 
@@ -105,20 +105,20 @@ public class SearchTextTask extends QueueableAsyncTask<String, SearchResult, Lis
                     return none();
                 }
 
-			}
-		} catch (IOException io) {
-			return none();
-		}
+            }
+        } catch (IOException io) {
+            return none();
+        }
 
-		return option(result);
-	}
-	
-	private static class DummyHandler extends TagNodeHandler {
-		@Override
-		public void handleTagNode(TagNode node, SpannableStringBuilder builder,
-				int start, int end, SpanStack stack) {
+        return option(result);
+    }
 
-			 builder.append("\uFFFC");
-		}
-	}
+    private static class DummyHandler extends TagNodeHandler {
+        @Override
+        public void handleTagNode(TagNode node, SpannableStringBuilder builder,
+            int start, int end, SpanStack stack) {
+
+            builder.append("\uFFFC");
+        }
+    }
 }

--- a/src/net/nightwhistler/pageturner/fragment/AddBookmarkFragment.java
+++ b/src/net/nightwhistler/pageturner/fragment/AddBookmarkFragment.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013 Alex Kuiper, Rob Hoelz
- * 
+ *
  * This file is part of PageTurner
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,7 +46,7 @@ public class AddBookmarkFragment extends RoboSherlockDialogFragment {
     private EditText inputField;
 
     private static final Logger LOG = LoggerFactory
-            .getLogger(AddBookmarkFragment.class);
+        .getLogger(AddBookmarkFragment.class);
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
@@ -59,21 +59,21 @@ public class AddBookmarkFragment extends RoboSherlockDialogFragment {
         this.inputField.setText(this.initialText);
 
         inputField.setOnEditorActionListener( (v, actionId, event) -> {
-            if (actionId == EditorInfo.IME_ACTION_DONE) {
-                handleAction();
-                return true;
-            } else {
-                return false;
-            }
-        });
+                if (actionId == EditorInfo.IME_ACTION_DONE) {
+                    handleAction();
+                    return true;
+                } else {
+                    return false;
+                }
+            });
 
         return new AlertDialog.Builder(
-                getActivity())
-                .setTitle(R.string.add_bookmark)
-                .setView( view )
-                .setPositiveButton(R.string.add, (dialog, which) -> handleAction() )
-                .setNegativeButton(android.R.string.cancel, null)
-                .create();
+            getActivity())
+            .setTitle(R.string.add_bookmark)
+            .setView( view )
+            .setPositiveButton(R.string.add, (dialog, which) -> handleAction() )
+            .setNegativeButton(android.R.string.cancel, null)
+            .create();
     }
 
     public void setFilename(String filename) {
@@ -104,8 +104,8 @@ public class AddBookmarkFragment extends RoboSherlockDialogFragment {
         LOG.debug("    >>> at position: " + bookPosition);
 
         bookmarkDatabaseHelper.addBookmark(
-                new Bookmark( filename, inputField.getText().toString(),
-                        bookIndex, bookPosition));
+            new Bookmark( filename, inputField.getText().toString(),
+                bookIndex, bookPosition));
     }
 
 }

--- a/src/net/nightwhistler/pageturner/fragment/BookDetailsFragment.java
+++ b/src/net/nightwhistler/pageturner/fragment/BookDetailsFragment.java
@@ -157,11 +157,11 @@ public class BookDetailsFragment extends RoboSherlockFragment implements LoadFee
 
         if ( !isEmpty( buyLink ) ) {
             buyNowButton.setOnClickListener( v -> {
-                String url = buyLink.unsafeGet().getHref();
-                Intent i = new Intent(Intent.ACTION_VIEW);
-                i.setData(Uri.parse(url));
-                startActivity(i);
-            });
+                    String url = buyLink.unsafeGet().getHref();
+                    Intent i = new Intent(Intent.ACTION_VIEW);
+                    i.setData(Uri.parse(url));
+                    startActivity(i);
+                });
         } else {
             buyNowButton.setVisibility(View.GONE);
 
@@ -172,8 +172,8 @@ public class BookDetailsFragment extends RoboSherlockFragment implements LoadFee
 
         if (entry.getAuthor() != null) {
             String authorText = String.format(
-                    getString(R.string.book_by), entry.getAuthor()
-                    .getName());
+                getString(R.string.book_by), entry.getAuthor()
+                .getName());
             authorTextView.setText(authorText);
         } else {
             authorTextView.setText("");
@@ -222,7 +222,7 @@ public class BookDetailsFragment extends RoboSherlockFragment implements LoadFee
             icon.setImageDrawable(drawable);
         }
 
-       onLoadingDone();
+        onLoadingDone();
     }
 
     @Override
@@ -283,7 +283,7 @@ public class BookDetailsFragment extends RoboSherlockFragment implements LoadFee
             Intent intent;
 
             intent = new Intent(context,
-                    ReadingActivity.class);
+                ReadingActivity.class);
             config.setLastActivity( ReadingActivity.class );
 
             intent.setData(Uri.parse(destFile.getAbsolutePath()));
@@ -312,7 +312,7 @@ public class BookDetailsFragment extends RoboSherlockFragment implements LoadFee
         private Context context;
 
         public NotificationBarCallback(Context context, String title,
-                                       boolean openOnCompletion) {
+            boolean openOnCompletion) {
             super( context, openOnCompletion );
             this.title = title;
             this.downloadSubtitle = getString(R.string.downloading);
@@ -329,8 +329,8 @@ public class BookDetailsFragment extends RoboSherlockFragment implements LoadFee
 
             builder = new NotificationCompat.Builder(context);
             builder.setContentTitle(title)
-                    .setContentText(downloadSubtitle)
-                    .setSmallIcon(R.drawable.download);
+                .setContentText(downloadSubtitle)
+                .setSmallIcon(R.drawable.download);
             builder.setTicker(downloadSubtitle);
 
             builder.setProgress( 0, 0, true);
@@ -352,11 +352,11 @@ public class BookDetailsFragment extends RoboSherlockFragment implements LoadFee
         public void downloadSuccess(File destFile) {
 
             builder.setContentText(downloadSuccess)
-                    // Removes the progress bar
-                    .setProgress(0, 0, false);
+                // Removes the progress bar
+                .setProgress(0, 0, false);
 
             PendingIntent contentIntent = PendingIntent.getActivity(context, 0,
-                    getBookOpenIntent(destFile), 0);
+                getBookOpenIntent(destFile), 0);
             builder.setContentIntent( contentIntent );
             builder.setTicker(downloadSuccess);
             builder.setAutoCancel(true);
@@ -370,8 +370,8 @@ public class BookDetailsFragment extends RoboSherlockFragment implements LoadFee
         public void downloadFailed() {
 
             builder.setContentText(downloadFailed)
-                    // Removes the progress bar
-                    .setProgress(0, 0, false);
+                // Removes the progress bar
+                .setProgress(0, 0, false);
             builder.setAutoCancel(true);
 
             notificationManager.notify(notificationId, builder.build());
@@ -380,7 +380,7 @@ public class BookDetailsFragment extends RoboSherlockFragment implements LoadFee
     }
 
     private class ProgressDialogCallback extends AbstractDownloadCallback implements
-        DialogInterface.OnCancelListener {
+                                                                              DialogInterface.OnCancelListener {
 
         private ProgressDialog downloadDialog;
         private DownloadFileTask task;
@@ -425,7 +425,7 @@ public class BookDetailsFragment extends RoboSherlockFragment implements LoadFee
 
             if ( ! isOpenOnCompletion() ) {
                 Toast.makeText(getActivity(), R.string.download_complete,
-                        Toast.LENGTH_LONG).show();
+                    Toast.LENGTH_LONG).show();
             }
         }
 
@@ -436,7 +436,7 @@ public class BookDetailsFragment extends RoboSherlockFragment implements LoadFee
 
             if ( isAdded() ) {
                 Toast.makeText(getActivity(), R.string.book_failed,
-                        Toast.LENGTH_LONG).show();
+                    Toast.LENGTH_LONG).show();
             }
         }
 

--- a/src/net/nightwhistler/pageturner/fragment/CatalogFragment.java
+++ b/src/net/nightwhistler/pageturner/fragment/CatalogFragment.java
@@ -67,16 +67,16 @@ import static jedi.functional.FunctionalPrimitives.isEmpty;
 import static jedi.option.Options.option;
 
 public class CatalogFragment extends RoboSherlockFragment implements LoadFeedCallback {
-	
-	private static final Logger LOG = LoggerFactory
-			.getLogger("CatalogFragment");
 
-	@InjectView(R.id.catalogList)
-	@Nullable
-	private ListView catalogList;
+    private static final Logger LOG = LoggerFactory
+        .getLogger("CatalogFragment");
 
-	@Inject
-	private Provider<LoadOPDSTask> loadOPDSTaskProvider;
+    @InjectView(R.id.catalogList)
+    @Nullable
+    private ListView catalogList;
+
+    @Inject
+    private Provider<LoadOPDSTask> loadOPDSTaskProvider;
 
     @Inject
     private Provider<ParseBinDataTask> parseBinDataTaskProvider;
@@ -88,7 +88,7 @@ public class CatalogFragment extends RoboSherlockFragment implements LoadFeedCal
     private DialogFactory dialogFactory;
 
     @Inject
-	private CatalogListAdapter adapter;
+    private CatalogListAdapter adapter;
 
     @Inject
     private Provider<DisplayMetrics> metricsProvider;
@@ -104,60 +104,60 @@ public class CatalogFragment extends RoboSherlockFragment implements LoadFeedCal
 
     private Feed staticFeed;
 
-	@Override
-	public void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
 
         DisplayMetrics metrics = metricsProvider.get();
         getActivity().getWindowManager().getDefaultDisplay().getMetrics(metrics);
 
         this.taskQueue.setTaskQueueListener( this::onLoadingDone );
-	}
+    }
 
     public void setBaseURL(  String baseURL ) {
         this.baseURL = baseURL;
     }
 
     @Override
-	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-		return inflater.inflate(R.layout.fragment_catalog, container, false);
-	}
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_catalog, container, false);
+    }
 
     @Override
-	public void onViewCreated(View view, Bundle savedInstanceState) {
-		super.onViewCreated(view, savedInstanceState);
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
 
-		setHasOptionsMenu(true);
-		catalogList.setAdapter(adapter);
+        setHasOptionsMenu(true);
+        catalogList.setAdapter(adapter);
         adapter.setImageLoader( (baseURL, link) ->
-                option(thumbnailCache.get(link.getHref())) );
+            option(thumbnailCache.get(link.getHref())) );
 
         catalogList.setOnScrollListener(new LoadingScrollListener());
 
         catalogList.setOnItemClickListener( (list, v, position, a) -> {
-            Option<Entry> entry = adapter.getItem(position);
-            entry.forEach( e -> onEntryClicked(e, position));
-        });
+                Option<Entry> entry = adapter.getItem(position);
+                entry.forEach( e -> onEntryClicked(e, position));
+            });
 
         if ( staticFeed != null ) {
             adapter.setFeed( staticFeed );
         }
 
-	}
+    }
 
     public void onBecameVisible() {
         adapter.getFeed().forEach( f ->
             ((CatalogParent) getActivity() ).onFeedLoaded( f )
-        );
+                                   );
     }
-	
-	private void loadOPDSFeed( Entry entry, String url, boolean asDetailsFeed, boolean asSearchFeed, ResultType resultType ) {
 
-		LoadOPDSTask task = this.loadOPDSTaskProvider.get();
-		task.setCallBack(this);
+    private void loadOPDSFeed( Entry entry, String url, boolean asDetailsFeed, boolean asSearchFeed, ResultType resultType ) {
+
+        LoadOPDSTask task = this.loadOPDSTaskProvider.get();
+        task.setCallBack(this);
 
         task.setResultType(resultType);
-		task.setAsDetailsFeed(asDetailsFeed);
+        task.setAsDetailsFeed(asDetailsFeed);
         task.setAsSearchFeed(asSearchFeed);
 
         //If we're going to load a completely new feed,
@@ -170,33 +170,33 @@ public class CatalogFragment extends RoboSherlockFragment implements LoadFeedCal
             this.adapter.setLoading(true);
         }
 
-	}
+    }
 
     public void setStaticFeed( Feed feed ) {
         this.staticFeed = feed;
     }
 
     public void performSearch(String searchTerm) {
-    	if (searchTerm != null && searchTerm.length() > 0) {
-			String searchString = URLEncoder.encode(searchTerm);
+        if (searchTerm != null && searchTerm.length() > 0) {
+            String searchString = URLEncoder.encode(searchTerm);
             Option<Feed> feed = adapter.getFeed();
 
             feed.forEach( f -> f.getSearchLink().forEach( searchLink -> {
-                String linkUrl = searchLink.getHref();
+                        String linkUrl = searchLink.getHref();
 
-                linkUrl = linkUrl.replace( AtomConstants.SEARCH_TERMS,
-                        searchString);
+                        linkUrl = linkUrl.replace( AtomConstants.SEARCH_TERMS,
+                            searchString);
 
-                loadURL(null, linkUrl, false, true, ResultType.REPLACE);
-            }));
-		}
+                        loadURL(null, linkUrl, false, true, ResultType.REPLACE);
+                    }));
+        }
     }
 
     public boolean supportsSearch() {
         return searchMenuItem.isEnabled();
     }
 
-	public void onSearchRequested() {
+    public void onSearchRequested() {
 
         if ( searchMenuItem == null || ! searchMenuItem.isEnabled() ) {
             return;
@@ -208,27 +208,27 @@ public class CatalogFragment extends RoboSherlockFragment implements LoadFeedCal
         } else {
             dialogFactory.showSearchDialog(R.string.search_books, R.string.enter_query, this::performSearch );
         }
-	}
+    }
 
-	public void onEntryClicked( Entry entry, int position ) {		
-			
-		if ( entry.getId() != null && entry.getId().equals(Catalog.CUSTOM_SITES_ID) ) {			
+    public void onEntryClicked( Entry entry, int position ) {
+
+        if ( entry.getId() != null && entry.getId().equals(Catalog.CUSTOM_SITES_ID) ) {
             ((CatalogParent) getActivity()).loadCustomSitesFeed();
-		} else if ( ! isEmpty( entry.getAlternateLink() ) ) {
-			String href = entry.getAlternateLink().unsafeGet().getHref();
-			replaceFeed(entry, href, true);
-		} else if ( ! isEmpty( entry.getEpubLink() )) {
+        } else if ( ! isEmpty( entry.getAlternateLink() ) ) {
+            String href = entry.getAlternateLink().unsafeGet().getHref();
+            replaceFeed(entry, href, true);
+        } else if ( ! isEmpty( entry.getEpubLink() )) {
             loadFakeFeek(entry);
-		} else if ( ! isEmpty(entry.getAtomLink()) ) {
-			String href = entry.getAtomLink().unsafeGet().getHref();
-			replaceFeed( entry, href, false);
-		} else if ( ! isEmpty( entry.getWebsiteLink() ) ) {
+        } else if ( ! isEmpty(entry.getAtomLink()) ) {
+            String href = entry.getAtomLink().unsafeGet().getHref();
+            replaceFeed( entry, href, false);
+        } else if ( ! isEmpty( entry.getWebsiteLink() ) ) {
             String url = entry.getWebsiteLink().unsafeGet().getHref();
             Intent i = new Intent(Intent.ACTION_VIEW);
             i.setData(Uri.parse(url));
             startActivity(i);
         }
-	}
+    }
 
     private void replaceFeed( Entry entry, String href, boolean asDetailsFeed ) {
 
@@ -268,23 +268,23 @@ public class CatalogFragment extends RoboSherlockFragment implements LoadFeedCal
 
         LOG.debug("Using baseURL: " + base);
 
-		try {
-			String target = url;
-			
-			if ( base != null && ! base.equals(Catalog.CUSTOM_SITES_ID)) {
-				target = new URL(new URL(base), url).toString();
-			}
+        try {
+            String target = url;
 
-			LOG.info("Loading " + target);
+            if ( base != null && ! base.equals(Catalog.CUSTOM_SITES_ID)) {
+                target = new URL(new URL(base), url).toString();
+            }
 
-			loadOPDSFeed(entry, target, asDetailsFeed, asSearchFeed, resultType);
-		} catch (MalformedURLException u) {
-			LOG.error("Malformed URL:", u);
-		}
-	}
+            LOG.info("Loading " + target);
 
-	@Override
-	public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+            loadOPDSFeed(entry, target, asDetailsFeed, asSearchFeed, resultType);
+        } catch (MalformedURLException u) {
+            LOG.error("Malformed URL:", u);
+        }
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
 
         SherlockFragmentActivity activity = getSherlockActivity();
 
@@ -292,8 +292,8 @@ public class CatalogFragment extends RoboSherlockFragment implements LoadFeedCal
             return;
         }
 
-		activity.getSupportActionBar().setHomeButtonEnabled(true);
-		inflater.inflate(R.menu.catalog_menu, menu);
+        activity.getSupportActionBar().setHomeButtonEnabled(true);
+        inflater.inflate(R.menu.catalog_menu, menu);
 
         this.searchMenuItem = menu.findItem(R.id.search);
         if (searchMenuItem != null) {
@@ -305,40 +305,40 @@ public class CatalogFragment extends RoboSherlockFragment implements LoadFeedCal
             } else {
                 searchMenuItem.setOnMenuItemClickListener( item -> {
                         dialogFactory.showSearchDialog(R.string.search_books,
-                                R.string.enter_query, this::performSearch );
+                            R.string.enter_query, this::performSearch );
                         return false;
-                });
+                    });
             }
         }
-	}
-	
-	@Override
-	public void onPrepareOptionsMenu(Menu menu) {
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
 
         Option<Feed> feed = adapter.getFeed();
 
         boolean searchEnabled = !isEmpty( (Option<Link>) feed.flatMap(Feed::getSearchLink) );
 
-		for ( int i=0; i < menu.size(); i++ ) {
-			MenuItem item = menu.getItem(i);
-			
-			boolean enabled;
-			
-			switch (item.getItemId()) {
+        for ( int i=0; i < menu.size(); i++ ) {
+            MenuItem item = menu.getItem(i);
 
-			case R.id.search:
-				enabled = searchEnabled;
-				break;			
-			default:
-				enabled = true;
-			}			
-			
-			item.setEnabled(enabled);
-			item.setVisible(enabled);			
-		}
+            boolean enabled;
+
+            switch (item.getItemId()) {
+
+            case R.id.search:
+                enabled = searchEnabled;
+                break;
+            default:
+                enabled = true;
+            }
+
+            item.setEnabled(enabled);
+            item.setVisible(enabled);
+        }
 
         LOG.debug("Adapter has feed: " + adapter.getFeed());
-	}
+    }
 
     @Override
     public void notifyLinkUpdated(Link link, Drawable drawable) {
@@ -350,12 +350,12 @@ public class CatalogFragment extends RoboSherlockFragment implements LoadFeedCal
     }
 
     @Override
-	public void errorLoadingFeed(String error) {
-		if ( isAdded() ) {
+    public void errorLoadingFeed(String error) {
+        if ( isAdded() ) {
             Toast.makeText(getActivity(), getString(R.string.feed_failed) + ": " + error,
-				Toast.LENGTH_LONG).show();
+                Toast.LENGTH_LONG).show();
         }
-	}
+    }
 
     @Override
     public void emptyFeedLoaded(Feed feed) {
@@ -487,17 +487,17 @@ public class CatalogFragment extends RoboSherlockFragment implements LoadFeedCal
                 Option<Entry> lastEntry = adapter.getItem( adapter.getCount() -1 );
 
                 lastEntry.flatMap(Entry::getFeed).forEach( feed -> feed.getNextLink().forEach( link -> {
-                    if (! link.getHref().equals(lastLoadedUrl)) {
-                        Entry nextEntry = new Entry();
-                        nextEntry.setFeed(feed);
-                        nextEntry.addLink(link);
+                            if (! link.getHref().equals(lastLoadedUrl)) {
+                                Entry nextEntry = new Entry();
+                                nextEntry.setFeed(feed);
+                                nextEntry.addLink(link);
 
-                        LOG.debug("Starting download for " + link.getHref() + " after scroll");
+                                LOG.debug("Starting download for " + link.getHref() + " after scroll");
 
-                        lastLoadedUrl = link.getHref();
-                        loadURL(nextEntry, link.getHref(), false, false, ResultType.APPEND);
-                    }
-                }));
+                                lastLoadedUrl = link.getHref();
+                                loadURL(nextEntry, link.getHref(), false, false, ResultType.APPEND);
+                            }
+                        }));
             }
         }
 
@@ -511,12 +511,12 @@ public class CatalogFragment extends RoboSherlockFragment implements LoadFeedCal
                     Option<Entry> entry = adapter.getItem( firstVisibleItem + i );
 
                     entry.forEach( e -> e.getFeed().forEach( feed -> {
-                        Catalog.getImageLink( feed, e).forEach( imageLink -> {
-                            if ( ! thumbnailCache.containsKey( imageLink.getHref() ) ) {
-                                queueImageLoading( e.getBaseURL(), imageLink );
-                            }
-                        });
-                    }));
+                                Catalog.getImageLink( feed, e).forEach( imageLink -> {
+                                        if ( ! thumbnailCache.containsKey( imageLink.getHref() ) ) {
+                                            queueImageLoading( e.getBaseURL(), imageLink );
+                                        }
+                                    });
+                            }));
                 }
             };
 

--- a/src/net/nightwhistler/pageturner/fragment/FileBrowseFragment.java
+++ b/src/net/nightwhistler/pageturner/fragment/FileBrowseFragment.java
@@ -39,47 +39,47 @@ import java.util.*;
 
 public class FileBrowseFragment extends RoboSherlockListFragment {
 
-	private FileAdapter adapter;
-	
-	@Inject
-	private Configuration config;
+    private FileAdapter adapter;
 
-	@Override
-	public void onCreate(Bundle savedInstanceState) {	
-		super.onCreate(savedInstanceState);
-		
-		Uri data = getActivity().getIntent().getData();		
-		
-		File file = null;
-		
-		if ( data != null && data.getPath() != null ) {
-			file = new File(data.getPath());
-		}
-		
-		if (file == null || ! (file.exists() && file.isDirectory()) ) {
-			file = config.getStorageBase().unsafeGet();
-		}
-		
-		if (file == null || ! (file.exists() && file.isDirectory()) ) {
-			file = new File("/");
-		}
-		
-		this.adapter = new FileAdapter(this.getActivity());
+    @Inject
+    private Configuration config;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Uri data = getActivity().getIntent().getData();
+
+        File file = null;
+
+        if ( data != null && data.getPath() != null ) {
+            file = new File(data.getPath());
+        }
+
+        if (file == null || ! (file.exists() && file.isDirectory()) ) {
+            file = config.getStorageBase().unsafeGet();
+        }
+
+        if (file == null || ! (file.exists() && file.isDirectory()) ) {
+            file = new File("/");
+        }
+
+        this.adapter = new FileAdapter(this.getActivity());
         this.adapter.setItemSelectionListener( this::returnFile );
 
-		adapter.setFolder(file);
-		getActivity().setTitle(adapter.getCurrentFolder());
-	}
+        adapter.setFolder(file);
+        getActivity().setTitle(adapter.getCurrentFolder());
+    }
 
-	@Override
-	public void onViewCreated(View view, Bundle savedInstanceState) {
-		super.onViewCreated(view, savedInstanceState);
-		setListAdapter(adapter);
-	}
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        setListAdapter(adapter);
+    }
 
-	@Override
-	public void onListItemClick(ListView l, View v, int position, long id) {
-		FileItem fileItem = this.adapter.getItem(position);
+    @Override
+    public void onListItemClick(ListView l, View v, int position, long id) {
+        FileItem fileItem = this.adapter.getItem(position);
 
         if ( fileItem.isImportOnClick() ) {
             returnFile(fileItem.getFile());
@@ -88,7 +88,7 @@ public class FileBrowseFragment extends RoboSherlockListFragment {
             getActivity().setTitle(adapter.getCurrentFolder());
         }
 
-	}
+    }
 
     private void returnFile( File file ) {
         Intent intent = getActivity().getIntent();

--- a/src/net/nightwhistler/pageturner/fragment/LibraryFragment.java
+++ b/src/net/nightwhistler/pageturner/fragment/LibraryFragment.java
@@ -80,153 +80,153 @@ import static net.nightwhistler.pageturner.PlatformUtil.isIntentAvailable;
 public class LibraryFragment extends RoboSherlockFragment implements ImportCallback {
 
     protected static final int REQUEST_CODE_GET_CONTENT = 2;
-	
-	@Inject 
-	private LibraryService libraryService;
+
+    @Inject
+    private LibraryService libraryService;
 
     @Inject
     private DialogFactory dialogFactory;
-	
-	@InjectView(R.id.libraryList)
-	private ListView listView;
-	
-	@InjectView(R.id.bookCaseView)
-	private BookCaseView bookCaseView;
-		
-	@InjectView(R.id.alphabetList)
-	private ListView alphabetBar;
-	
-	private AlphabetAdapter alphabetAdapter;
-	
-	@InjectView(R.id.alphabetDivider)
-	private ImageView alphabetDivider;
-	
-	@InjectView(R.id.libHolder)
-	private ViewSwitcher switcher;
+
+    @InjectView(R.id.libraryList)
+    private ListView listView;
+
+    @InjectView(R.id.bookCaseView)
+    private BookCaseView bookCaseView;
+
+    @InjectView(R.id.alphabetList)
+    private ListView alphabetBar;
+
+    private AlphabetAdapter alphabetAdapter;
+
+    @InjectView(R.id.alphabetDivider)
+    private ImageView alphabetDivider;
+
+    @InjectView(R.id.libHolder)
+    private ViewSwitcher switcher;
 
     @Inject
     private Context context;
-	
-	@Inject
-	private Configuration config;
+
+    @Inject
+    private Configuration config;
 
     @Inject
     private TaskQueue taskQueue;
 
-	private Drawable backupCover;
-	private Handler handler;
-		
-	private KeyedResultAdapter bookAdapter;
-		
-	private static final DateFormat DATE_FORMAT = DateFormat.getDateInstance(DateFormat.LONG);
-	private static final int ALPHABET_THRESHOLD = 20;
-	
-	private ProgressDialog waitDialog;
-	private ProgressDialog importDialog;	
-	
-	private AlertDialog importQuestion;
-	
-	private boolean askedUserToImport;
-	private boolean oldKeepScreenOn;
-	
-	private static final Logger LOG = LoggerFactory.getLogger("LibraryActivity");
+    private Drawable backupCover;
+    private Handler handler;
 
-	private IntentCallBack intentCallBack;
-	private List<CoverCallback> callbacks = new ArrayList<>();
-	private Map<String, FastBitmapDrawable> coverCache = new HashMap<>();
+    private KeyedResultAdapter bookAdapter;
+
+    private static final DateFormat DATE_FORMAT = DateFormat.getDateInstance(DateFormat.LONG);
+    private static final int ALPHABET_THRESHOLD = 20;
+
+    private ProgressDialog waitDialog;
+    private ProgressDialog importDialog;
+
+    private AlertDialog importQuestion;
+
+    private boolean askedUserToImport;
+    private boolean oldKeepScreenOn;
+
+    private static final Logger LOG = LoggerFactory.getLogger("LibraryActivity");
+
+    private IntentCallBack intentCallBack;
+    private List<CoverCallback> callbacks = new ArrayList<>();
+    private Map<String, FastBitmapDrawable> coverCache = new HashMap<>();
 
     private MenuItem searchMenuItem;
 
-	private interface IntentCallBack {
-		void onResult( int resultCode, Intent data );
-	}
-	
-	@Override
-	public void onCreate(Bundle savedInstanceState) {			
-		super.onCreate(savedInstanceState);
+    private interface IntentCallBack {
+        void onResult( int resultCode, Intent data );
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
 
         LOG.debug("onCreate()");
-		
-		Bitmap backupBitmap = BitmapFactory.decodeResource(getResources(), R.drawable.unknown_cover );
-		this.backupCover = new FastBitmapDrawable(backupBitmap);
-		
-		this.handler = new Handler();
-				
-		if ( savedInstanceState != null ) {
-			this.askedUserToImport = savedInstanceState.getBoolean("import_q", false);
-		}
+
+        Bitmap backupBitmap = BitmapFactory.decodeResource(getResources(), R.drawable.unknown_cover );
+        this.backupCover = new FastBitmapDrawable(backupBitmap);
+
+        this.handler = new Handler();
+
+        if ( savedInstanceState != null ) {
+            this.askedUserToImport = savedInstanceState.getBoolean("import_q", false);
+        }
 
         this.taskQueue.setTaskQueueListener(this::onTaskQueueEmpty);
-	}
+    }
 
-	@Override
-	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-		return inflater.inflate(R.layout.fragment_library, container, false);
-	}
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_library, container, false);
+    }
 
-	@Override
-	public void onViewCreated(View view, Bundle savedInstanceState) {
-		super.onViewCreated(view, savedInstanceState);
-		setHasOptionsMenu(true);
-		this.bookCaseView.setOnScrollListener( new CoverScrollListener() );
-		this.listView.setOnScrollListener( new CoverScrollListener() );
-		
-		if ( config.getLibraryView() == LibraryView.BOOKCASE ) {
-			
-			this.bookAdapter = new BookCaseAdapter();
-			this.bookCaseView.setAdapter(bookAdapter);			
-			
-			if ( switcher.getDisplayedChild() == 0 ) {
-				switcher.showNext();
-			}
-		} else {		
-			this.bookAdapter = new BookListAdapter(context);
-			this.listView.setAdapter(bookAdapter);
-		}
+    @Override
+    public void onViewCreated(View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        setHasOptionsMenu(true);
+        this.bookCaseView.setOnScrollListener( new CoverScrollListener() );
+        this.listView.setOnScrollListener( new CoverScrollListener() );
 
-		this.waitDialog = new ProgressDialog(context);
-		this.waitDialog.setOwnerActivity(getActivity());
-		
-		this.importDialog = new ProgressDialog(context);
-		
-		this.importDialog.setOwnerActivity(getActivity());
-		importDialog.setTitle(R.string.importing_books);
-		importDialog.setMessage(getString(R.string.scanning_epub));
-		registerForContextMenu(this.listView);	
+        if ( config.getLibraryView() == LibraryView.BOOKCASE ) {
+
+            this.bookAdapter = new BookCaseAdapter();
+            this.bookCaseView.setAdapter(bookAdapter);
+
+            if ( switcher.getDisplayedChild() == 0 ) {
+                switcher.showNext();
+            }
+        } else {
+            this.bookAdapter = new BookListAdapter(context);
+            this.listView.setAdapter(bookAdapter);
+        }
+
+        this.waitDialog = new ProgressDialog(context);
+        this.waitDialog.setOwnerActivity(getActivity());
+
+        this.importDialog = new ProgressDialog(context);
+
+        this.importDialog.setOwnerActivity(getActivity());
+        importDialog.setTitle(R.string.importing_books);
+        importDialog.setMessage(getString(R.string.scanning_epub));
+        registerForContextMenu(this.listView);
 
         this.listView.setOnItemClickListener( this::onItemClick );
-		this.listView.setOnItemLongClickListener(this::onItemLongClick );
-		
-		setAlphabetBarVisible(false);
-	}
+        this.listView.setOnItemLongClickListener(this::onItemLongClick );
 
-	@Override
-	public void onActivityCreated(Bundle savedInstanceState) {
-		super.onActivityCreated(savedInstanceState);
-		ActionBar actionBar = getSherlockActivity().getSupportActionBar();
-		actionBar.setDisplayShowTitleEnabled(false);
-		actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_LIST);
-		ArrayAdapter<String> adapter = new ArrayAdapter<>(actionBar.getThemedContext(),
-				android.R.layout.simple_list_item_1,
-				android.R.id.text1, getResources().getStringArray(R.array.libraryQueries));
+        setAlphabetBarVisible(false);
+    }
 
-		actionBar.setListNavigationCallbacks(adapter, this::onNavigationItemSelected );
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        ActionBar actionBar = getSherlockActivity().getSupportActionBar();
+        actionBar.setDisplayShowTitleEnabled(false);
+        actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_LIST);
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(actionBar.getThemedContext(),
+            android.R.layout.simple_list_item_1,
+            android.R.id.text1, getResources().getStringArray(R.array.libraryQueries));
+
+        actionBar.setListNavigationCallbacks(adapter, this::onNavigationItemSelected );
 
         refreshView();
 
-		Option<File> libraryFolder = config.getLibraryFolder();
+        Option<File> libraryFolder = config.getLibraryFolder();
         LOG.debug( "Got libraryFolder: " + libraryFolder );
 
-		libraryFolder.match( folder -> {
-			executeTask(new CleanFilesTask(libraryService, this::booksDeleted) );
-			executeTask(new ImportTask(getActivity(), libraryService, this, config, config.getCopyToLibraryOnScan(),
-					true), folder );
-		}, () -> {
-			LOG.error("No library folder present!");
-			Toast.makeText( context, R.string.library_failed, Toast.LENGTH_LONG ).show();
-		});
+        libraryFolder.match( folder -> {
+                executeTask(new CleanFilesTask(libraryService, this::booksDeleted) );
+                executeTask(new ImportTask(getActivity(), libraryService, this, config, config.getCopyToLibraryOnScan(),
+                        true), folder );
+            }, () -> {
+                LOG.error("No library folder present!");
+                Toast.makeText( context, R.string.library_failed, Toast.LENGTH_LONG ).show();
+            });
 
-	}
+    }
 
     private <A,B,C> void executeTask( QueueableAsyncTask<A,B,C> task, A... parameters ) {
         setSupportProgressBarIndeterminateVisibility(true);
@@ -242,25 +242,25 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
     }
 
     private void clearCoverCache() {
-		for ( Map.Entry<String, FastBitmapDrawable> draw: coverCache.entrySet() ) {
-			draw.getValue().destroy();
-		}
+        for ( Map.Entry<String, FastBitmapDrawable> draw: coverCache.entrySet() ) {
+            draw.getValue().destroy();
+        }
 
-		coverCache.clear();
-	}
+        coverCache.clear();
+    }
 
-	private void onItemClick(AdapterView<?> parent, View view, int position,
-			long id) {
+    private void onItemClick(AdapterView<?> parent, View view, int position,
+        long id) {
 
         if ( config.getLongShortPressBehaviour() == Configuration.LongShortPressBehaviour.NORMAL ) {
             this.bookAdapter.getResultAt( position ).forEach( this::showBookDetails );
         } else {
             this.bookAdapter.getResultAt( position ).forEach( this::openBook );
         }
-	}	
+    }
 
-	private boolean onItemLongClick(AdapterView<?> parent, View view,
-			int position, long id) {
+    private boolean onItemLongClick(AdapterView<?> parent, View view,
+        int position, long id) {
 
         if ( config.getLongShortPressBehaviour() == Configuration.LongShortPressBehaviour.NORMAL ) {
             this.bookAdapter.getResultAt( position ).forEach(this::openBook);
@@ -268,10 +268,10 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
             this.bookAdapter.getResultAt( position ).forEach( this::showBookDetails );
         }
 
-		return true;
-	}
+        return true;
+    }
 
-	private Option<Drawable> getCover( LibraryBook book ) {
+    private Option<Drawable> getCover( LibraryBook book ) {
 
         try {
             if ( !coverCache.containsKey(book.getFileName() ) ) {
@@ -286,105 +286,105 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
             clearCoverCache();
             return none();
         }
-	}
-	
-	private void showBookDetails( final LibraryBook libraryBook ) {
+    }
+
+    private void showBookDetails( final LibraryBook libraryBook ) {
 
         if ( ! isAdded() || libraryBook == null ) {
             return;
         }
-		
-		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-		builder.setTitle(R.string.book_details);
-		LayoutInflater inflater = PlatformUtil.getLayoutInflater(getActivity());
-		
-		View layout = inflater.inflate(R.layout.book_details, null);
-		builder.setView( layout );
-		
-		ImageView coverView = (ImageView) layout.findViewById(R.id.coverImage );
 
-		if ( libraryBook.getCoverImage() != null ) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.book_details);
+        LayoutInflater inflater = PlatformUtil.getLayoutInflater(getActivity());
+
+        View layout = inflater.inflate(R.layout.book_details, null);
+        builder.setView( layout );
+
+        ImageView coverView = (ImageView) layout.findViewById(R.id.coverImage );
+
+        if ( libraryBook.getCoverImage() != null ) {
             Drawable coverDrawable = getCover(libraryBook).getOrElse(
-                    getResources().getDrawable(R.drawable.unknown_cover) );
+                getResources().getDrawable(R.drawable.unknown_cover) );
 
             coverView.setImageDrawable(coverDrawable);
         }
 
-		TextView titleView = (TextView) layout.findViewById(R.id.titleField);
-		TextView authorView = (TextView) layout.findViewById(R.id.authorField);
-		TextView lastRead = (TextView) layout.findViewById(R.id.lastRead);
-		TextView added = (TextView) layout.findViewById(R.id.addedToLibrary);
-		TextView descriptionView = (TextView) layout.findViewById(R.id.bookDescription);
-		TextView fileName = (TextView) layout.findViewById(R.id.fileName);
-		
-		titleView.setText(libraryBook.getTitle());
-		String authorText = String.format( getString(R.string.book_by),
-				 libraryBook.getAuthor().getFirstName() + " " 
-				 + libraryBook.getAuthor().getLastName() );
-		authorView.setText( authorText );
-		fileName.setText( libraryBook.getFileName() );
+        TextView titleView = (TextView) layout.findViewById(R.id.titleField);
+        TextView authorView = (TextView) layout.findViewById(R.id.authorField);
+        TextView lastRead = (TextView) layout.findViewById(R.id.lastRead);
+        TextView added = (TextView) layout.findViewById(R.id.addedToLibrary);
+        TextView descriptionView = (TextView) layout.findViewById(R.id.bookDescription);
+        TextView fileName = (TextView) layout.findViewById(R.id.fileName);
 
-		if (libraryBook.getLastRead() != null && ! libraryBook.getLastRead().equals(new Date(0))) {
-			String lastReadText = String.format(getString(R.string.last_read),
-					DATE_FORMAT.format(libraryBook.getLastRead()));
-			lastRead.setText( lastReadText );
-		} else {
-			String lastReadText = String.format(getString(R.string.last_read), getString(R.string.never_read));
-			lastRead.setText( lastReadText );
-		}
+        titleView.setText(libraryBook.getTitle());
+        String authorText = String.format( getString(R.string.book_by),
+            libraryBook.getAuthor().getFirstName() + " "
+            + libraryBook.getAuthor().getLastName() );
+        authorView.setText( authorText );
+        fileName.setText( libraryBook.getFileName() );
 
-		String addedText = String.format( getString(R.string.added_to_lib),
-				DATE_FORMAT.format(libraryBook.getAddedToLibrary()));
-		added.setText( addedText );
+        if (libraryBook.getLastRead() != null && ! libraryBook.getLastRead().equals(new Date(0))) {
+            String lastReadText = String.format(getString(R.string.last_read),
+                DATE_FORMAT.format(libraryBook.getLastRead()));
+            lastRead.setText( lastReadText );
+        } else {
+            String lastReadText = String.format(getString(R.string.last_read), getString(R.string.never_read));
+            lastRead.setText( lastReadText );
+        }
+
+        String addedText = String.format( getString(R.string.added_to_lib),
+            DATE_FORMAT.format(libraryBook.getAddedToLibrary()));
+        added.setText( addedText );
 
         HtmlSpanner spanner = new HtmlSpanner();
         spanner.unregisterHandler("img" ); //We don't want to render images
 
-		descriptionView.setText(spanner.fromHtml( libraryBook.getDescription()));
+        descriptionView.setText(spanner.fromHtml( libraryBook.getDescription()));
 
         builder.setNeutralButton(R.string.delete, (dialog, which) -> {
-            libraryService.deleteBook( libraryBook.getFileName() );
-            refreshView();
-            dialog.dismiss();
-        });
-		
-		builder.setNegativeButton(android.R.string.cancel, null);
-		builder.setPositiveButton(R.string.read, (dialog, which) -> openBook(libraryBook) );
+                libraryService.deleteBook( libraryBook.getFileName() );
+                refreshView();
+                dialog.dismiss();
+            });
 
-		builder.show();
-	}
-	
-	private void openBook(LibraryBook libraryBook) {
-		Intent intent = new Intent(getActivity(), ReadingActivity.class);
+        builder.setNegativeButton(android.R.string.cancel, null);
+        builder.setPositiveButton(R.string.read, (dialog, which) -> openBook(libraryBook) );
+
+        builder.show();
+    }
+
+    private void openBook(LibraryBook libraryBook) {
+        Intent intent = new Intent(getActivity(), ReadingActivity.class);
         config.setLastActivity( ReadingActivity.class );
 
-		intent.setData( Uri.parse(libraryBook.getFileName()));
-		getActivity().setResult(Activity.RESULT_OK, intent);
-				
-		getActivity().startActivityIfNeeded(intent, 99);		
-	}
-		
-	private void startImport(File startFolder, boolean copy) {		
-		ImportTask importTask = new ImportTask(context, libraryService, this, config, copy, false);
-		importDialog.setOnCancelListener(importTask);
-		importDialog.show();		
-				
-		this.oldKeepScreenOn = listView.getKeepScreenOn();
-		listView.setKeepScreenOn(true);
+        intent.setData( Uri.parse(libraryBook.getFileName()));
+        getActivity().setResult(Activity.RESULT_OK, intent);
+
+        getActivity().startActivityIfNeeded(intent, 99);
+    }
+
+    private void startImport(File startFolder, boolean copy) {
+        ImportTask importTask = new ImportTask(context, libraryService, this, config, copy, false);
+        importDialog.setOnCancelListener(importTask);
+        importDialog.show();
+
+        this.oldKeepScreenOn = listView.getKeepScreenOn();
+        listView.setKeepScreenOn(true);
 
         this.taskQueue.clear();
         executeTask(importTask, startFolder);
-	}
+    }
 
     @Override
-	public void onActivityResult(int requestCode, int resultCode, Intent data) {
-		if ( this.intentCallBack != null ) {
-			this.intentCallBack.onResult(resultCode, data);
-		}
-	}
-	
-	@Override
-	public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {		
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if ( this.intentCallBack != null ) {
+            this.intentCallBack.onResult(resultCode, data);
+        }
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.library_menu, menu);
 
         UiUtils.Action toggleListener = () -> {
@@ -424,9 +424,9 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
 
             } else {
                 searchMenuItem.setOnMenuItemClickListener( item -> {
-                    dialogFactory.showSearchDialog(R.string.search_library, R.string.enter_query, this::performSearch);
-                    return false;
-                });
+                        dialogFactory.showSearchDialog(R.string.search_library, R.string.enter_query, this::performSearch);
+                        return false;
+                    });
             }
         }
 
@@ -441,7 +441,7 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
             menu.findItem(R.id.open_file).setVisible(false);
         }
 
-	}
+    }
 
     private void launchFileManager() {
         Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
@@ -464,7 +464,7 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
         } catch (ActivityNotFoundException e) {
             // No compatible file manager was found.
             Toast.makeText(getActivity(), getString(R.string.install_oi),
-                    Toast.LENGTH_SHORT).show();
+                Toast.LENGTH_SHORT).show();
         }
     }
 
@@ -483,134 +483,134 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
             this.taskQueue.jumpQueueExecuteTask(new LoadBooksTask(config.getLastLibraryQuery(), query));
         }
     }
-	
-	private void switchToColourProfile( ColourProfile profile ) {
-		config.setColourProfile(profile);
-		Intent intent = new Intent(getActivity(), LibraryActivity.class);
-		startActivity(intent);
-		onStop();
-		getActivity().finish();
-	}
-	
-	@Override
-	public void onPrepareOptionsMenu(Menu menu) {
-		boolean bookCaseActive = config.getLibraryView() == LibraryView.BOOKCASE;
-		
-		menu.findItem(R.id.shelves_view).setVisible(! bookCaseActive);
-		menu.findItem(R.id.list_view).setVisible(bookCaseActive);
-		menu.findItem(R.id.profile_day).setVisible(config.getColourProfile() == ColourProfile.NIGHT);
-		menu.findItem(R.id.profile_night).setVisible(config.getColourProfile() == ColourProfile.DAY);
-	}
-	
-	private void showImportDialog() {
-		AlertDialog.Builder builder;		
-		
-		LayoutInflater inflater = PlatformUtil.getLayoutInflater(getActivity());
-		final View layout = inflater.inflate(R.layout.import_dialog, null);
-		final RadioButton scanSpecific = (RadioButton) layout.findViewById(R.id.radioScanFolder);
-		final TextView folder = (TextView) layout.findViewById(R.id.folderToScan);
-		final CheckBox copyToLibrary = (CheckBox) layout.findViewById(R.id.copyToLib);		
-		final Button browseButton = (Button) layout.findViewById(R.id.browseButton);
 
-		Option<File> storageBase = config.getStorageBase();
-		if ( isEmpty(storageBase) ) {
-			return;
-		}
+    private void switchToColourProfile( ColourProfile profile ) {
+        config.setColourProfile(profile);
+        Intent intent = new Intent(getActivity(), LibraryActivity.class);
+        startActivity(intent);
+        onStop();
+        getActivity().finish();
+    }
 
-		folder.setOnClickListener( v ->	scanSpecific.setChecked(true) );
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        boolean bookCaseActive = config.getLibraryView() == LibraryView.BOOKCASE;
 
-		// Copy scan settings from the prefs
-		copyToLibrary.setChecked( config.getCopyToLibraryOnScan() );
-		scanSpecific.setChecked( config.getUseCustomScanFolder() );
-		folder.setText( config.getScanFolder() );
+        menu.findItem(R.id.shelves_view).setVisible(! bookCaseActive);
+        menu.findItem(R.id.list_view).setVisible(bookCaseActive);
+        menu.findItem(R.id.profile_day).setVisible(config.getColourProfile() == ColourProfile.NIGHT);
+        menu.findItem(R.id.profile_night).setVisible(config.getColourProfile() == ColourProfile.DAY);
+    }
 
-		builder = new AlertDialog.Builder(getActivity());
-		builder.setView(layout);
+    private void showImportDialog() {
+        AlertDialog.Builder builder;
+
+        LayoutInflater inflater = PlatformUtil.getLayoutInflater(getActivity());
+        final View layout = inflater.inflate(R.layout.import_dialog, null);
+        final RadioButton scanSpecific = (RadioButton) layout.findViewById(R.id.radioScanFolder);
+        final TextView folder = (TextView) layout.findViewById(R.id.folderToScan);
+        final CheckBox copyToLibrary = (CheckBox) layout.findViewById(R.id.copyToLib);
+        final Button browseButton = (Button) layout.findViewById(R.id.browseButton);
+
+        Option<File> storageBase = config.getStorageBase();
+        if ( isEmpty(storageBase) ) {
+            return;
+        }
+
+        folder.setOnClickListener( v -> scanSpecific.setChecked(true) );
+
+        // Copy scan settings from the prefs
+        copyToLibrary.setChecked( config.getCopyToLibraryOnScan() );
+        scanSpecific.setChecked( config.getUseCustomScanFolder() );
+        folder.setText( config.getScanFolder() );
+
+        builder = new AlertDialog.Builder(getActivity());
+        builder.setView(layout);
 
         this.intentCallBack = (int resultCode, Intent data) -> {
             if ( resultCode == Activity.RESULT_OK && data != null ) {
                 folder.setText(data.getData().getPath());
             }
         };
-		
-		browseButton.setOnClickListener(v -> {
-            scanSpecific.setChecked(true);
-            Intent intent = new Intent(getActivity(), FileBrowseActivity.class);
-            intent.setData( Uri.parse(folder.getText().toString() ));
-            startActivityForResult(intent, 0);
-        });
-		
-		builder.setTitle(R.string.import_books);
+
+        browseButton.setOnClickListener(v -> {
+                scanSpecific.setChecked(true);
+                Intent intent = new Intent(getActivity(), FileBrowseActivity.class);
+                intent.setData( Uri.parse(folder.getText().toString() ));
+                startActivityForResult(intent, 0);
+            });
+
+        builder.setTitle(R.string.import_books);
 
         builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
-            dialog.dismiss();
+                dialog.dismiss();
 
-	    /* Update settings */
-	    config.setUseCustomScanFolder( scanSpecific.isChecked() );
-	    config.setCopyToLibraryOnScan( copyToLibrary.isChecked() );
+                /* Update settings */
+                config.setUseCustomScanFolder( scanSpecific.isChecked() );
+                config.setCopyToLibraryOnScan( copyToLibrary.isChecked() );
 
-            File folderToScan;
-            if ( scanSpecific.isChecked() ) {
-		String path = folder.getText().toString();
-                folderToScan = new File(path);
-		config.setScanFolder(path); /* update custom path only if used */
-            } else {
-                File default_storage = storageBase.unsafeGet();
-                folderToScan = new File(default_storage.getAbsolutePath());
-            }
+                File folderToScan;
+                if ( scanSpecific.isChecked() ) {
+                    String path = folder.getText().toString();
+                    folderToScan = new File(path);
+                    config.setScanFolder(path); /* update custom path only if used */
+                } else {
+                    File default_storage = storageBase.unsafeGet();
+                    folderToScan = new File(default_storage.getAbsolutePath());
+                }
 
-            startImport(folderToScan, copyToLibrary.isChecked());
-        });
+                startImport(folderToScan, copyToLibrary.isChecked());
+            });
 
-		builder.setNegativeButton(android.R.string.cancel, null);
-		
-		builder.show();
-	}	
-	
-	@Override
-	public void onSaveInstanceState(Bundle outState) {
-		outState.putBoolean("import_q", askedUserToImport);
-	}
-	
-	@Override
-	public void onStop() {
-		this.libraryService.close();	
-		this.waitDialog.dismiss();
-		this.importDialog.dismiss();
-		super.onStop();
-	}
-	
-	public void onBackPressed() {
-		getActivity().finish();			
-	}	
-	
-	@Override
-	public void onPause() {
-		
-		this.bookAdapter.clear();
-		//We clear the list to free up memory.
+        builder.setNegativeButton(android.R.string.cancel, null);
+
+        builder.show();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putBoolean("import_q", askedUserToImport);
+    }
+
+    @Override
+    public void onStop() {
+        this.libraryService.close();
+        this.waitDialog.dismiss();
+        this.importDialog.dismiss();
+        super.onStop();
+    }
+
+    public void onBackPressed() {
+        getActivity().finish();
+    }
+
+    @Override
+    public void onPause() {
+
+        this.bookAdapter.clear();
+        //We clear the list to free up memory.
 
         this.taskQueue.clear();
-		this.clearCoverCache();
-		
-		super.onPause();
-	}
-	
-	
-	@Override
-	public void onResume() {
-		super.onResume();				
-		
-		LibrarySelection lastSelection = config.getLastLibraryQuery();
-		
-		ActionBar actionBar = getSherlockActivity().getSupportActionBar();
-		
-		if (actionBar.getSelectedNavigationIndex() != lastSelection.ordinal() ) {
-			actionBar.setSelectedNavigationItem(lastSelection.ordinal());
-		} else {
+        this.clearCoverCache();
+
+        super.onPause();
+    }
+
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        LibrarySelection lastSelection = config.getLastLibraryQuery();
+
+        ActionBar actionBar = getSherlockActivity().getSupportActionBar();
+
+        if (actionBar.getSelectedNavigationIndex() != lastSelection.ordinal() ) {
+            actionBar.setSelectedNavigationItem(lastSelection.ordinal());
+        } else {
             executeTask(new LoadBooksTask(lastSelection));
-		}
-	}
+        }
+    }
 
     @Override
     public void importCancelled(int booksImported, List<String> failures, boolean emptyLibrary, boolean silent) {
@@ -619,13 +619,13 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
     }
 
     @Override
-	public void importComplete(int booksImported, List<String> errors, boolean emptyLibrary, boolean silent) {
+    public void importComplete(int booksImported, List<String> errors, boolean emptyLibrary, boolean silent) {
         LOG.debug("Got importComplete() ");
         afterImport(booksImported, errors, emptyLibrary, silent, false);
-	}
+    }
 
     private void afterImport(int booksImported, List<String> errors, boolean emptyLibrary, boolean silent,
-                             boolean cancelledByUser ) {
+        boolean cancelledByUser ) {
 
         if ( !isAdded() || getActivity() == null ) {
             return;
@@ -687,108 +687,108 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
         }
 
     }
-	
-	
-	@Override
-	public void importFailed(String reason, boolean silent) {
+
+
+    @Override
+    public void importFailed(String reason, boolean silent) {
 
         LOG.debug("Got importFailed()");
-		
-		if (silent || !isAdded() || getActivity() == null ) {
-			return;
-		}
-		
-		importDialog.hide();
-		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-		builder.setTitle(R.string.import_failed);
-		builder.setMessage(reason);
-		builder.setNeutralButton(android.R.string.ok, null);
-		builder.show();
-	}
-	
-	@Override
-	public void importStatusUpdate(String update, boolean silent) {
-		
-		if (silent || !isAdded() || getActivity() == null ) {
-			return;
-		}
-		
-		importDialog.setMessage(update);
-	}	
-	
-	public void onAlphabetBarClick( KeyedQueryResult<LibraryBook> result, Character c ) {
 
-		result.getOffsetFor(toUpperCase(c)).forEach( index -> {
-			if ( alphabetAdapter != null ) {
-				alphabetAdapter.setHighlightChar(c);
-			}
+        if (silent || !isAdded() || getActivity() == null ) {
+            return;
+        }
 
-			if ( config.getLibraryView() == LibraryView.BOOKCASE ) {
-				this.bookCaseView.setSelection(index);
-			} else {
-				this.listView.setSelection(index);
-			}
-		});
-	}	
-	
-	
-	/**
-	 * Based on example found here:
-	 * http://www.vogella.de/articles/AndroidListView/article.html
-	 * 
-	 * @author work
-	 *
-	 */
-	private class BookListAdapter extends KeyedResultAdapter {	
-		
-		private Context context;		
-		
-		public BookListAdapter(Context context) {
-			this.context = context;
-		}		
-		
-		@Override
-		public View getView(int index, final LibraryBook book, View convertView,
-				ViewGroup parent) {
-			
-			View rowView;
-			
-			if ( convertView == null ) {			
-				LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-				rowView = inflater.inflate(R.layout.book_row, parent, false);
-			} else {
-				rowView = convertView;
-			}			
-			
-			TextView titleView = (TextView) rowView.findViewById(R.id.bookTitle);
-			TextView authorView = (TextView) rowView.findViewById(R.id.bookAuthor);
-			TextView dateView = (TextView) rowView.findViewById(R.id.addedToLibrary);
-			TextView progressView = (TextView) rowView.findViewById(R.id.readingProgress);
-			
-			final ImageView imageView = (ImageView) rowView.findViewById(R.id.bookCover);
-						
-			String authorText = String.format(getString(R.string.book_by),
-					book.getAuthor().getFirstName() + " " + book.getAuthor().getLastName() );
-			
-			authorView.setText(authorText);
-			titleView.setText(book.getTitle());
-			
-			if ( book.getProgress() > 0 ) {
-				progressView.setText( "" + book.getProgress() + "%");
-			} else {
-				progressView.setText("");
-			}			
-			
-			String dateText = String.format(getString(R.string.added_to_lib),
-					DATE_FORMAT.format(book.getAddedToLibrary()));
-			dateView.setText( dateText );
-			
-			loadCover(imageView, book, index);			
-			
-			return rowView;
-		}	
-	
-	}
+        importDialog.hide();
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.import_failed);
+        builder.setMessage(reason);
+        builder.setNeutralButton(android.R.string.ok, null);
+        builder.show();
+    }
+
+    @Override
+    public void importStatusUpdate(String update, boolean silent) {
+
+        if (silent || !isAdded() || getActivity() == null ) {
+            return;
+        }
+
+        importDialog.setMessage(update);
+    }
+
+    public void onAlphabetBarClick( KeyedQueryResult<LibraryBook> result, Character c ) {
+
+        result.getOffsetFor(toUpperCase(c)).forEach( index -> {
+                if ( alphabetAdapter != null ) {
+                    alphabetAdapter.setHighlightChar(c);
+                }
+
+                if ( config.getLibraryView() == LibraryView.BOOKCASE ) {
+                    this.bookCaseView.setSelection(index);
+                } else {
+                    this.listView.setSelection(index);
+                }
+            });
+    }
+
+
+    /**
+     * Based on example found here:
+     * http://www.vogella.de/articles/AndroidListView/article.html
+     *
+     * @author work
+     *
+     */
+    private class BookListAdapter extends KeyedResultAdapter {
+
+        private Context context;
+
+        public BookListAdapter(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public View getView(int index, final LibraryBook book, View convertView,
+            ViewGroup parent) {
+
+            View rowView;
+
+            if ( convertView == null ) {
+                LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+                rowView = inflater.inflate(R.layout.book_row, parent, false);
+            } else {
+                rowView = convertView;
+            }
+
+            TextView titleView = (TextView) rowView.findViewById(R.id.bookTitle);
+            TextView authorView = (TextView) rowView.findViewById(R.id.bookAuthor);
+            TextView dateView = (TextView) rowView.findViewById(R.id.addedToLibrary);
+            TextView progressView = (TextView) rowView.findViewById(R.id.readingProgress);
+
+            final ImageView imageView = (ImageView) rowView.findViewById(R.id.bookCover);
+
+            String authorText = String.format(getString(R.string.book_by),
+                book.getAuthor().getFirstName() + " " + book.getAuthor().getLastName() );
+
+            authorView.setText(authorText);
+            titleView.setText(book.getTitle());
+
+            if ( book.getProgress() > 0 ) {
+                progressView.setText( "" + book.getProgress() + "%");
+            } else {
+                progressView.setText("");
+            }
+
+            String dateText = String.format(getString(R.string.added_to_lib),
+                DATE_FORMAT.format(book.getAddedToLibrary()));
+            dateView.setText( dateText );
+
+            loadCover(imageView, book, index);
+
+            return rowView;
+        }
+
+    }
 
     private void loadView( LibrarySelection selection, String from ) {
         LOG.debug("Loading view: " + selection + " from " + from);
@@ -817,24 +817,24 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
     }
 
     private void loadCover( ImageView imageView, LibraryBook book, int index ) {
-		Drawable draw = coverCache.get(book.getFileName());
-		
-		if ( draw != null ) {
-			imageView.setImageDrawable(draw);
-		} else {
-			
-			imageView.setImageDrawable(backupCover);
-			
-			if ( book.getCoverImage() != null ) {				
-				callbacks.add( new CoverCallback(book, index, imageView ) );
-			}
-		}
-	}	
-	
-	private class CoverScrollListener implements AbsListView.OnScrollListener {
-		
-		private Runnable lastRunnable;
-		private Character lastCharacter;
+        Drawable draw = coverCache.get(book.getFileName());
+
+        if ( draw != null ) {
+            imageView.setImageDrawable(draw);
+        } else {
+
+            imageView.setImageDrawable(backupCover);
+
+            if ( book.getCoverImage() != null ) {
+                callbacks.add( new CoverCallback(book, index, imageView ) );
+            }
+        }
+    }
+
+    private class CoverScrollListener implements AbsListView.OnScrollListener {
+
+        private Runnable lastRunnable;
+        private Character lastCharacter;
 
         private Drawable holoDrawable;
 
@@ -845,18 +845,18 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
                 //leave it null
             }
         }
-		
-		@Override
-		public void onScroll(AbsListView view, final int firstVisibleItem,
-				final int visibleItemCount, final int totalItemCount) {
-			
-			if ( visibleItemCount == 0  ) {
-				return;
-			}
-			
-			if ( this.lastRunnable != null ) {
-				handler.removeCallbacks(lastRunnable);
-			}
+
+        @Override
+        public void onScroll(AbsListView view, final int firstVisibleItem,
+            final int visibleItemCount, final int totalItemCount) {
+
+            if ( visibleItemCount == 0  ) {
+                return;
+            }
+
+            if ( this.lastRunnable != null ) {
+                handler.removeCallbacks(lastRunnable);
+            }
 
             this.lastRunnable = () -> {
 
@@ -905,103 +905,103 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
                 }
 
             };
-				
-			handler.postDelayed(lastRunnable, 550);			
-		}
-		
-		@Override
-		public void onScrollStateChanged(AbsListView view, int scrollState) {
-					
-		}
 
-	}
+            handler.postDelayed(lastRunnable, 550);
+        }
 
-	private class CoverCallback {
-		protected LibraryBook book;
-		protected int viewIndex;
-		protected ImageView view;
+        @Override
+        public void onScrollStateChanged(AbsListView view, int scrollState) {
 
-		public CoverCallback(LibraryBook book, int viewIndex, ImageView view) {
-			this.book = book;
-			this.view = view;
-			this.viewIndex = viewIndex;
-		}
+        }
 
-		public void run() {
-			try {
+    }
+
+    private class CoverCallback {
+        protected LibraryBook book;
+        protected int viewIndex;
+        protected ImageView view;
+
+        public CoverCallback(LibraryBook book, int viewIndex, ImageView view) {
+            this.book = book;
+            this.view = view;
+            this.viewIndex = viewIndex;
+        }
+
+        public void run() {
+            try {
                 getCover(book).forEach( view::setImageDrawable );
             } catch (IllegalStateException i) {
                 //Do nothing, happens when we're no longer attached.
             }
-		}
-	}
+        }
+    }
 
 
-	private class BookCaseAdapter extends KeyedResultAdapter {
-				
-		@Override
-		public View getView(final int index, final LibraryBook object, View convertView,
-				ViewGroup parent) {
-			
-			View result;
-		
-			if ( convertView == null ) {				
-				LayoutInflater inflater = PlatformUtil.getLayoutInflater(getActivity());
-				result = inflater.inflate(R.layout.bookcase_row, parent, false);
-				
-			} else {
-				result = convertView;
-			}			
-			
-			result.setTag(index);
-			
-			result.setOnClickListener( v -> LibraryFragment.this.onItemClick(null, null, index, 0) );
-			result.setOnLongClickListener( v -> LibraryFragment.this.onItemLongClick(null, null, index, 0));
-			
-			final ImageView image = (ImageView) result.findViewById(R.id.bookCover);
-			image.setImageDrawable(backupCover);
-			TextView text = (TextView) result.findViewById(R.id.bookLabel);
-			text.setText( object.getTitle() );
-			text.setBackgroundResource(R.drawable.alphabet_bar_bg_dark);			
-			
-			loadCover(image, object, index);		
-			
-			return result;
-		}
-		
-	}
-	
-	private void buildImportQuestionDialog() {
-		
-		if ( importQuestion != null || ! isAdded() ) {
-			return;
-		}
-		
-		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-		builder.setTitle(R.string.no_books_found);
-		builder.setMessage( getString(R.string.scan_bks_question) );
+    private class BookCaseAdapter extends KeyedResultAdapter {
+
+        @Override
+        public View getView(final int index, final LibraryBook object, View convertView,
+            ViewGroup parent) {
+
+            View result;
+
+            if ( convertView == null ) {
+                LayoutInflater inflater = PlatformUtil.getLayoutInflater(getActivity());
+                result = inflater.inflate(R.layout.bookcase_row, parent, false);
+
+            } else {
+                result = convertView;
+            }
+
+            result.setTag(index);
+
+            result.setOnClickListener( v -> LibraryFragment.this.onItemClick(null, null, index, 0) );
+            result.setOnLongClickListener( v -> LibraryFragment.this.onItemLongClick(null, null, index, 0));
+
+            final ImageView image = (ImageView) result.findViewById(R.id.bookCover);
+            image.setImageDrawable(backupCover);
+            TextView text = (TextView) result.findViewById(R.id.bookLabel);
+            text.setText( object.getTitle() );
+            text.setBackgroundResource(R.drawable.alphabet_bar_bg_dark);
+
+            loadCover(image, object, index);
+
+            return result;
+        }
+
+    }
+
+    private void buildImportQuestionDialog() {
+
+        if ( importQuestion != null || ! isAdded() ) {
+            return;
+        }
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.no_books_found);
+        builder.setMessage( getString(R.string.scan_bks_question) );
 
         builder.setPositiveButton(android.R.string.yes, (dialog, which) -> {
-            dialog.dismiss();
-            showImportDialog();
-        });
+                dialog.dismiss();
+                showImportDialog();
+            });
 
         builder.setNegativeButton(android.R.string.no, (dialog, which ) -> {
-            dialog.dismiss();
-            importQuestion = null;
-        });
+                dialog.dismiss();
+                importQuestion = null;
+            });
 
         this.importQuestion = builder.create();
-	}
-	
-	private void setAlphabetBarVisible( boolean visible ) {
-		
-		int vis = visible ? View.VISIBLE : View.GONE; 
-		
-		alphabetBar.setVisibility(vis);
-		alphabetDivider.setVisibility(vis);		
-		listView.setFastScrollEnabled(visible);
-	}
+    }
+
+    private void setAlphabetBarVisible( boolean visible ) {
+
+        int vis = visible ? View.VISIBLE : View.GONE;
+
+        alphabetBar.setVisibility(vis);
+        alphabetDivider.setVisibility(vis);
+        listView.setFastScrollEnabled(visible);
+    }
 
     private void setSupportProgressBarIndeterminateVisibility(boolean enable) {
         SherlockFragmentActivity activity = getSherlockActivity();
@@ -1027,41 +1027,41 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
         return false;
     }
 
-	private class AlphabetAdapter extends ArrayAdapter<Character> {
-		
-		private List<Character> data;
-		
-		private Character highlightChar;
-		
-		public AlphabetAdapter(Context context, int layout, int view, List<Character> input ) {
-			super(context, layout, view, input);
-			this.data = input;
-		}
-		
-		@Override
-		public View getView(int position, View convertView, ViewGroup parent) {
-			View view = super.getView(position, convertView, parent);
-			
-			Character tag = data.get(position);
-			view.setTag( tag );
-			
-			if ( tag.equals(highlightChar) ) {
-				view.setBackgroundDrawable( getResources().getDrawable(R.drawable.list_activated_holo));
-			} else {
-				view.setBackgroundDrawable(null);
-			}
-			
-			return view;
-		}
-		
-		public void setHighlightChar(Character highlightChar) {
-			this.highlightChar = highlightChar;
-		}
-		
-		public Character getHighlightChar() {
-			return highlightChar;
-		}
-	}
+    private class AlphabetAdapter extends ArrayAdapter<Character> {
+
+        private List<Character> data;
+
+        private Character highlightChar;
+
+        public AlphabetAdapter(Context context, int layout, int view, List<Character> input ) {
+            super(context, layout, view, input);
+            this.data = input;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            View view = super.getView(position, convertView, parent);
+
+            Character tag = data.get(position);
+            view.setTag( tag );
+
+            if ( tag.equals(highlightChar) ) {
+                view.setBackgroundDrawable( getResources().getDrawable(R.drawable.list_activated_holo));
+            } else {
+                view.setBackgroundDrawable(null);
+            }
+
+            return view;
+        }
+
+        public void setHighlightChar(Character highlightChar) {
+            this.highlightChar = highlightChar;
+        }
+
+        public Character getHighlightChar() {
+            return highlightChar;
+        }
+    }
 
     private void loadQueryData( QueryResult<LibraryBook> result ) {
         if ( !isAdded() || getActivity() == null ) {
@@ -1075,12 +1075,12 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
             final KeyedQueryResult<LibraryBook> keyedResult = (KeyedQueryResult<LibraryBook>) result;
 
             alphabetAdapter = new AlphabetAdapter(getActivity(),
-                    R.layout.alphabet_line, R.id.alphabetLabel,	keyedResult.getAlphabet() );
+                R.layout.alphabet_line, R.id.alphabetLabel,   keyedResult.getAlphabet() );
 
             alphabetBar.setAdapter(alphabetAdapter);
 
             alphabetBar.setOnItemClickListener( (a, b, index, c) ->
-                    onAlphabetBarClick(keyedResult, keyedResult.getAlphabet().get(index) ));
+                onAlphabetBarClick(keyedResult, keyedResult.getAlphabet().get(index) ));
 
             setAlphabetBarVisible(true);
         } else {
@@ -1089,9 +1089,9 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
         }
     }
 
-	private class LoadBooksTask extends QueueableAsyncTask<String, Integer, QueryResult<LibraryBook>> {
-		
-		private Configuration.LibrarySelection sel;
+    private class LoadBooksTask extends QueueableAsyncTask<String, Integer, QueryResult<LibraryBook>> {
+
+        private Configuration.LibrarySelection sel;
         private String filter;
 
         public LoadBooksTask(LibrarySelection selection) {
@@ -1106,61 +1106,61 @@ public class LibraryFragment extends RoboSherlockFragment implements ImportCallb
         @Override
         public void doOnPreExecute() {
             if ( this.filter == null )  {
-			    coverCache.clear();
+                coverCache.clear();
             }
-		}
-		
-		@Override
-		public Option<QueryResult<LibraryBook>> doInBackground(String... params) {
-			
-			Exception storedException = null;
+        }
+
+        @Override
+        public Option<QueryResult<LibraryBook>> doInBackground(String... params) {
+
+            Exception storedException = null;
 
             String query = this.filter;
-			
-			for ( int i=0; i < 3; i++ ) {
 
-				try {
+            for ( int i=0; i < 3; i++ ) {
 
-					switch ( sel ) {			
-					case LAST_ADDED:
-						return some(libraryService.findAllByLastAdded(query));
-					case UNREAD:
-						return some(libraryService.findUnread(query));
-					case BY_TITLE:
-						return some(libraryService.findAllByTitle(query));
-					case BY_AUTHOR:
-						return some(libraryService.findAllByAuthor(query));
-					default:
-						return some(libraryService.findAllByLastRead(query));
-					}
-				} catch (SQLiteException sql) {
-					storedException = sql;
-					try {
-						//Sometimes the database is still locked.
-						Thread.sleep(1000);
-					} catch (InterruptedException in) {}
-				}				
-			}
-			
-			LOG.error( "Failed after 3 attempts", storedException );
+                try {
+
+                    switch ( sel ) {
+                    case LAST_ADDED:
+                        return some(libraryService.findAllByLastAdded(query));
+                    case UNREAD:
+                        return some(libraryService.findUnread(query));
+                    case BY_TITLE:
+                        return some(libraryService.findAllByTitle(query));
+                    case BY_AUTHOR:
+                        return some(libraryService.findAllByAuthor(query));
+                    default:
+                        return some(libraryService.findAllByLastRead(query));
+                    }
+                } catch (SQLiteException sql) {
+                    storedException = sql;
+                    try {
+                        //Sometimes the database is still locked.
+                        Thread.sleep(1000);
+                    } catch (InterruptedException in) {}
+                }
+            }
+
+            LOG.error( "Failed after 3 attempts", storedException );
             return none();
-		}
+        }
 
         @Override
         public void doOnPostExecute(Option<QueryResult<LibraryBook>> result) {
 
             result.match(r -> {
 
-                loadQueryData(r);
+                    loadQueryData(r);
 
-                if (filter == null && sel == Configuration.LibrarySelection.LAST_ADDED && r.getSize() == 0 && !askedUserToImport) {
-                    askedUserToImport = true;
-                    buildImportQuestionDialog();
-                    importQuestion.show();
-                }
-            }, () -> Toast.makeText(context, R.string.library_failed, Toast.LENGTH_SHORT).show());
+                    if (filter == null && sel == Configuration.LibrarySelection.LAST_ADDED && r.getSize() == 0 && !askedUserToImport) {
+                        askedUserToImport = true;
+                        buildImportQuestionDialog();
+                        importQuestion.show();
+                    }
+                }, () -> Toast.makeText(context, R.string.library_failed, Toast.LENGTH_SHORT).show());
 
-		}
-		
-	}
+        }
+
+    }
 }

--- a/src/net/nightwhistler/pageturner/fragment/ReadingFragment.java
+++ b/src/net/nightwhistler/pageturner/fragment/ReadingFragment.java
@@ -101,7 +101,7 @@ import static net.nightwhistler.pageturner.PlatformUtil.*;
 import static net.nightwhistler.ui.UiUtils.onMenuPress;
 
 public class ReadingFragment extends RoboSherlockFragment implements
-        BookViewListener, TextSelectionCallback {
+                                                              BookViewListener, TextSelectionCallback {
 
     private static final String POS_KEY = "offset:";
     private static final String IDX_KEY = "index:";
@@ -116,7 +116,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
     public static final String EXTRA_MARGIN_LEFT = "EXTRA_MARGIN_LEFT";
 
     private static final Logger LOG = LoggerFactory
-            .getLogger("ReadingFragment");
+        .getLogger("ReadingFragment");
 
     @Inject
     Provider<ActionModeBuilder> actionModeBuilderProvider;
@@ -209,10 +209,10 @@ public class ReadingFragment extends RoboSherlockFragment implements
     private BookmarkDatabaseHelper bookmarkDatabaseHelper;
 
     /*
-    This is actually a RemoteControlClient, but we declare it
-    as an object, since the RemoteControlClient class is
-    only available in ICS and later.
-     */
+      This is actually a RemoteControlClient, but we declare it
+      as an object, since the RemoteControlClient class is
+      only available in ICS and later.
+    */
     private Object remoteControlClient;
 
     private MenuItem searchMenuItem;
@@ -296,46 +296,46 @@ public class ReadingFragment extends RoboSherlockFragment implements
         this.progressBar.setFocusable(true);
         this.progressBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
 
-            private int seekValue;
+                private int seekValue;
 
-            @Override
-            public void onStopTrackingTouch(SeekBar seekBar) {
-                bookView.navigateToPercentage(this.seekValue);
-            }
-
-            @Override
-            public void onStartTrackingTouch(SeekBar seekBar) {
-            }
-
-            @Override
-            public void onProgressChanged(SeekBar seekBar,
-                                          int progress, boolean fromUser) {
-                if (fromUser) {
-                    seekValue = progress;
-                    percentageField.setText(progress + "% ");
+                @Override
+                public void onStopTrackingTouch(SeekBar seekBar) {
+                    bookView.navigateToPercentage(this.seekValue);
                 }
-            }
-        });
+
+                @Override
+                public void onStartTrackingTouch(SeekBar seekBar) {
+                }
+
+                @Override
+                public void onProgressChanged(SeekBar seekBar,
+                    int progress, boolean fromUser) {
+                    if (fromUser) {
+                        seekValue = progress;
+                        percentageField.setText(progress + "% ");
+                    }
+                }
+            });
 
         this.mediaProgressBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
 
-            @Override
-            public void onStopTrackingTouch(SeekBar seekBar) {
+                @Override
+                public void onStopTrackingTouch(SeekBar seekBar) {
 
-            }
-
-            @Override
-            public void onStartTrackingTouch(SeekBar seekBar) {
-            }
-
-            @Override
-            public void onProgressChanged(SeekBar seekBar,
-                                          int progress, boolean fromUser) {
-                if (fromUser) {
-                    seekToPointInPlayback(progress);
                 }
-            }
-        });
+
+                @Override
+                public void onStartTrackingTouch(SeekBar seekBar) {
+                }
+
+                @Override
+                public void onProgressChanged(SeekBar seekBar,
+                    int progress, boolean fromUser) {
+                    if (fromUser) {
+                        seekToPointInPlayback(progress);
+                    }
+                }
+            });
 
         this.textToSpeech = new TextToSpeech(context, this::onTextToSpeechInit );
 
@@ -355,7 +355,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
     public void onMediaButtonEvent( int buttonId ) {
 
         if ( buttonId == R.id.playPauseButton &&
-                ! ttsIsRunning() ) {
+            ! ttsIsRunning() ) {
             startTextToSpeech();
             return;
         }
@@ -371,26 +371,26 @@ public class ReadingFragment extends RoboSherlockFragment implements
         uiHandler.removeCallbacks(progressBarUpdater);
 
         switch ( buttonId ) {
-            case R.id.stopButton:
-                stopTextToSpeech(true);
-                return;
-            case R.id.nextButton:
-                performSkip(true);
-                uiHandler.post(progressBarUpdater);
-                return;
-            case R.id.prevButton:
-                performSkip(false);
-                uiHandler.post(progressBarUpdater);
-                return;
+        case R.id.stopButton:
+            stopTextToSpeech(true);
+            return;
+        case R.id.nextButton:
+            performSkip(true);
+            uiHandler.post(progressBarUpdater);
+            return;
+        case R.id.prevButton:
+            performSkip(false);
+            uiHandler.post(progressBarUpdater);
+            return;
 
-            case R.id.playPauseButton:
-                if ( mediaPlayer.isPlaying() ) {
-                    mediaPlayer.pause();
-                } else {
-                    mediaPlayer.start();
-                    uiHandler.post(progressBarUpdater);
-                }
-                return;
+        case R.id.playPauseButton:
+            if ( mediaPlayer.isPlaying() ) {
+                mediaPlayer.pause();
+            } else {
+                mediaPlayer.start();
+                uiHandler.post(progressBarUpdater);
+            }
+            return;
         }
     }
 
@@ -427,10 +427,10 @@ public class ReadingFragment extends RoboSherlockFragment implements
         displayPageNumber(-1); // Initializes the pagenumber view properly
 
         final GestureDetector gestureDetector = new GestureDetector(context,
-                new NavGestureDetector(bookView, this, metrics));
+            new NavGestureDetector(bookView, this, metrics));
 
         View.OnTouchListener gestureListener = (View v, MotionEvent event) ->
-                !ttsIsRunning() && gestureDetector.onTouchEvent(event);
+            !ttsIsRunning() && gestureDetector.onTouchEvent(event);
 
         this.viewSwitcher.setOnTouchListener(gestureListener);
         this.bookView.setOnTouchListener(gestureListener);
@@ -456,7 +456,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
         if ("".equals(fileName) || ! new File(fileName).exists() ) {
 
             LOG.info( "Requested to open file " + fileName + ", which doesn't seem to exist. " +
-                    "Switching back to the library.");
+                "Switching back to the library.");
 
             Intent newIntent = new Intent(context, LibraryActivity.class);
             startActivity(newIntent);
@@ -480,11 +480,11 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
         activity.getSupportActionBar().addOnMenuVisibilityListener( isVisible -> {
 
-            LOG.debug("Detected change of visibility in action-bar: visible=" + isVisible );
-            int visibility = isVisible ? View.VISIBLE : View.GONE;
-            titleBarLayout.setVisibility( visibility );
+                LOG.debug("Detected change of visibility in action-bar: visible=" + isVisible );
+                int visibility = isVisible ? View.VISIBLE : View.GONE;
+                titleBarLayout.setVisibility( visibility );
 
-        });
+            });
 
     }
 
@@ -641,8 +641,8 @@ public class ReadingFragment extends RoboSherlockFragment implements
         }
 
         String textToSpeak = text.map(
-                c -> c.toString().substring( bookView.getStartOfCurrentPage() )
-        ).getOrElse("");
+            c -> c.toString().substring( bookView.getStartOfCurrentPage() )
+                                      ).getOrElse("");
 
         List<String> parts = TextUtil.splitOnPunctuation(textToSpeak);
 
@@ -691,7 +691,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
     }
 
     private void streamPartToDisk(String fileName, String part, int offset, int totalLength, boolean endOfPage )
-            throws TTSFailedException {
+        throws TTSFailedException {
 
         LOG.debug("Request to stream text to file " + fileName + " with text " + part );
 
@@ -729,18 +729,18 @@ public class ReadingFragment extends RoboSherlockFragment implements
     private void showTTSFailed(final String message) {
         uiHandler.post( () -> {
 
-            stopTextToSpeech(true);
-            closeWaitDialog();
+                stopTextToSpeech(true);
+                closeWaitDialog();
 
-            if ( isAdded() ) {
-                playBeep(true);
+                if ( isAdded() ) {
+                    playBeep(true);
 
-                StringBuilder textBuilder = new StringBuilder( getString(R.string.tts_failed) );
-                textBuilder.append("\n").append(message);
+                    StringBuilder textBuilder = new StringBuilder( getString(R.string.tts_failed) );
+                    textBuilder.append("\n").append(message);
 
-                Toast.makeText(context, textBuilder.toString(), Toast.LENGTH_SHORT).show();
-            }
-        } );
+                    Toast.makeText(context, textBuilder.toString(), Toast.LENGTH_SHORT).show();
+                }
+            } );
     }
 
     /** Checked exception to indicate TTS failure **/
@@ -788,71 +788,71 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
     private Runnable progressBarUpdater = new Runnable() {
 
-        private boolean pausedBecauseOfCall = false;
+            private boolean pausedBecauseOfCall = false;
 
-        public void run() {
+            public void run() {
 
-            if ( ! ttsIsRunning() ) {
-                return;
-            }
+                if ( ! ttsIsRunning() ) {
+                    return;
+                }
 
-            long delay = 1000;
+                long delay = 1000;
 
-            synchronized ( ttsPlaybackItemQueue ) {
+                synchronized ( ttsPlaybackItemQueue ) {
 
-                TTSPlaybackItem item = ttsPlaybackItemQueue.peek();
+                    TTSPlaybackItem item = ttsPlaybackItemQueue.peek();
 
-                if ( item != null ) {
+                    if ( item != null ) {
 
-                    MediaPlayer mediaPlayer = item.getMediaPlayer();
+                        MediaPlayer mediaPlayer = item.getMediaPlayer();
 
-                    int phoneState = telephonyManager.getCallState();
+                        int phoneState = telephonyManager.getCallState();
 
-                    if ( mediaPlayer != null && mediaPlayer.isPlaying() ) {
+                        if ( mediaPlayer != null && mediaPlayer.isPlaying() ) {
 
-                        if ( phoneState == TelephonyManager.CALL_STATE_RINGING ||
+                            if ( phoneState == TelephonyManager.CALL_STATE_RINGING ||
                                 phoneState == TelephonyManager.CALL_STATE_OFFHOOK ) {
 
-                            LOG.debug("Detected call, pausing TTS.");
+                                LOG.debug("Detected call, pausing TTS.");
 
-                            mediaPlayer.pause();
-                            this.pausedBecauseOfCall = true;
-                        } else {
+                                mediaPlayer.pause();
+                                this.pausedBecauseOfCall = true;
+                            } else {
 
-                            double percentage = (double) mediaPlayer.getCurrentPosition() / (double) mediaPlayer.getDuration();
+                                double percentage = (double) mediaPlayer.getCurrentPosition() / (double) mediaPlayer.getDuration();
 
-                            mediaProgressBar.setMax(mediaPlayer.getDuration());
-                            mediaProgressBar.setProgress(mediaPlayer.getCurrentPosition());
+                                mediaProgressBar.setMax(mediaPlayer.getDuration());
+                                mediaProgressBar.setProgress(mediaPlayer.getCurrentPosition());
 
-                            int currentDuration = item.getOffset() + (int) (percentage * item.getText().length());
+                                int currentDuration = item.getOffset() + (int) (percentage * item.getText().length());
 
-                            bookView.navigateTo(bookView.getIndex(), currentDuration );
+                                bookView.navigateTo(bookView.getIndex(), currentDuration );
 
-                            wordView.setText( item.getText() );
+                                wordView.setText( item.getText() );
 
-                            delay = 100;
+                                delay = 100;
 
-                        }
+                            }
 
-                    } else if ( mediaPlayer != null && phoneState == TelephonyManager.CALL_STATE_IDLE
+                        } else if ( mediaPlayer != null && phoneState == TelephonyManager.CALL_STATE_IDLE
                             && pausedBecauseOfCall ) {
-                        LOG.debug("Call over, resuming TTS.");
+                            LOG.debug("Call over, resuming TTS.");
 
-                        //We reset to the start of the current section before resuming playback.
-                        mediaPlayer.seekTo(0);
+                            //We reset to the start of the current section before resuming playback.
+                            mediaPlayer.seekTo(0);
 
-                        mediaPlayer.start();
-                        pausedBecauseOfCall = false;
-                        delay = 100;
+                            mediaPlayer.start();
+                            pausedBecauseOfCall = false;
+                            delay = 100;
+                        }
                     }
                 }
+
+                // Running this thread after 100 milliseconds
+                uiHandler.postDelayed(this, delay);
+
             }
-
-            // Running this thread after 100 milliseconds
-            uiHandler.postDelayed(this, delay);
-
-        }
-    };
+        };
 
     @TargetApi(Build.VERSION_CODES.FROYO)
     private void subscribeToMediaButtons() {
@@ -879,14 +879,14 @@ public class ReadingFragment extends RoboSherlockFragment implements
         remoteControlIntent.setComponent(componentName);
 
         RemoteControlClient localRemoteControlClient = new RemoteControlClient(
-                PendingIntent.getBroadcast(context, 0, remoteControlIntent, 0));
+            PendingIntent.getBroadcast(context, 0, remoteControlIntent, 0));
 
         localRemoteControlClient.setTransportControlFlags(RemoteControlClient.FLAG_KEY_MEDIA_PLAY_PAUSE
-                        | RemoteControlClient.FLAG_KEY_MEDIA_NEXT
-                        | RemoteControlClient.FLAG_KEY_MEDIA_PREVIOUS
-                        | RemoteControlClient.FLAG_KEY_MEDIA_PLAY
-                        | RemoteControlClient.FLAG_KEY_MEDIA_PAUSE
-        );
+            | RemoteControlClient.FLAG_KEY_MEDIA_NEXT
+            | RemoteControlClient.FLAG_KEY_MEDIA_PREVIOUS
+            | RemoteControlClient.FLAG_KEY_MEDIA_PLAY
+            | RemoteControlClient.FLAG_KEY_MEDIA_PAUSE
+                                                          );
 
         audioManager.registerRemoteControlClient( localRemoteControlClient );
 
@@ -900,7 +900,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
             this.mediaReceiver = null;
 
             audioManager.unregisterMediaButtonEventReceiver(
-                    new ComponentName(context, MediaButtonReceiver.class));
+                new ComponentName(context, MediaButtonReceiver.class));
         }
     }
 
@@ -1040,7 +1040,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
     @Override
     public void progressUpdate(int progressPercentage, int pageNumber,
-                               int totalPages) {
+        int totalPages) {
 
         if ( ! isAdded() || getActivity() == null ) {
             return;
@@ -1057,7 +1057,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
         if (config.isShowPageNumbers() && pageNumber > 0) {
             percentageField.setText("" + progressPercentage + "%  "
-                    + pageNumber + " / " + totalPages);
+                + pageNumber + " / " + totalPages);
             displayPageNumber(pageNumber);
 
         } else {
@@ -1080,7 +1080,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
         SpannableStringBuilder builder = new SpannableStringBuilder(pageString);
         builder.setSpan(new CenterSpan(), 0, builder.length(),
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
         pageNumberView.setTextColor(config.getTextColor());
         pageNumberView.setTextSize(config.getTextSize());
 
@@ -1125,12 +1125,12 @@ public class ReadingFragment extends RoboSherlockFragment implements
         if (config.isFullScreenEnabled()) {
             activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
             activity.getWindow().clearFlags(
-                    WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
             activity.getSupportActionBar().hide();
 
         } else {
             activity.getWindow().addFlags(
-                    WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
             activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
             activity.getSupportActionBar().show();
         }
@@ -1138,8 +1138,8 @@ public class ReadingFragment extends RoboSherlockFragment implements
         if ( Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB ) {
             if ( config.isFullScreenEnabled() ) {
                 bookView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                        | View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+                    | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                    | View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
 
             }
             if ( config.isDimSystemUI() ) {
@@ -1149,51 +1149,51 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
         if (config.isKeepScreenOn()) {
             activity.getWindow()
-                    .addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                .addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         } else {
             activity.getWindow().clearFlags(
-                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         }
 
         restoreColorProfile();
 
         // Check if we need a restart
         if (config.isFullScreenEnabled() != savedConfigState.fullscreen
-                || config.isShowPageNumbers() != savedConfigState.usePageNum
-                || config.isBrightnessControlEnabled() != savedConfigState.brightness
-                || config.isStripWhiteSpaceEnabled() != savedConfigState.stripWhiteSpace
-                || !config.getDefaultFontFamily().getName().equalsIgnoreCase(savedConfigState.fontName)
-                || !config.getSerifFontFamily().getName().equalsIgnoreCase(savedConfigState.serifFontName)
-                || !config.getSansSerifFontFamily().getName().equalsIgnoreCase(savedConfigState.sansSerifFontName)
-                || config.getHorizontalMargin() != savedConfigState.hMargin
-                || config.getVerticalMargin() != savedConfigState.vMargin
-                || config.getTextSize() != savedConfigState.textSize
-                || config.isScrollingEnabled() != savedConfigState.scrolling
-                || config.isAllowStyling() != savedConfigState.allowStyling
-                || config.isUseColoursFromCSS() != savedConfigState.allowColoursFromCSS ) {
+            || config.isShowPageNumbers() != savedConfigState.usePageNum
+            || config.isBrightnessControlEnabled() != savedConfigState.brightness
+            || config.isStripWhiteSpaceEnabled() != savedConfigState.stripWhiteSpace
+            || !config.getDefaultFontFamily().getName().equalsIgnoreCase(savedConfigState.fontName)
+            || !config.getSerifFontFamily().getName().equalsIgnoreCase(savedConfigState.serifFontName)
+            || !config.getSansSerifFontFamily().getName().equalsIgnoreCase(savedConfigState.sansSerifFontName)
+            || config.getHorizontalMargin() != savedConfigState.hMargin
+            || config.getVerticalMargin() != savedConfigState.vMargin
+            || config.getTextSize() != savedConfigState.textSize
+            || config.isScrollingEnabled() != savedConfigState.scrolling
+            || config.isAllowStyling() != savedConfigState.allowStyling
+            || config.isUseColoursFromCSS() != savedConfigState.allowColoursFromCSS ) {
 
             textLoader.invalidateCachedText();
             restartActivity();
         }
 
         Configuration.OrientationLock orientation = config
-                .getScreenOrientation();
+            .getScreenOrientation();
 
         switch (orientation) {
-            case PORTRAIT:
-                getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-                break;
-            case LANDSCAPE:
-                getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
-                break;
-            case REVERSE_LANDSCAPE:
-                getActivity().setRequestedOrientation(8); // Android 2.3+ value
-                break;
-            case REVERSE_PORTRAIT:
-                getActivity().setRequestedOrientation(9); // Android 2.3+ value
-                break;
-            default:
-                getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        case PORTRAIT:
+            getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+            break;
+        case LANDSCAPE:
+            getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+            break;
+        case REVERSE_LANDSCAPE:
+            getActivity().setRequestedOrientation(8); // Android 2.3+ value
+            break;
+        case REVERSE_PORTRAIT:
+            getActivity().setRequestedOrientation(9); // Android 2.3+ value
+            break;
+        default:
+            getActivity().setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
         }
     }
 
@@ -1226,7 +1226,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
             updateFromPrefs();
         } else {
             getActivity().getWindow().clearFlags(
-                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
         }
     }
 
@@ -1257,27 +1257,27 @@ public class ReadingFragment extends RoboSherlockFragment implements
         activity.supportInvalidateOptionsMenu();
 
         if (book.getMetadata() != null
-                && !book.getMetadata().getAuthors().isEmpty()) {
+            && !book.getMetadata().getAuthors().isEmpty()) {
             Author author = book.getMetadata().getAuthors().get(0);
             this.authorField.setText(author.getFirstname() + " "
-                    + author.getLastname());
+                + author.getLastname());
         }
 
         backgroundHandler.post( () -> {
-            try {
-                libraryService.storeBook(fileName, book, true,
+                try {
+                    libraryService.storeBook(fileName, book, true,
                         config.getCopyToLibraryOnScan());
-            } catch (Exception io) {
-                LOG.error("Copy to library failed.", io);
-            }
-        });
+                } catch (Exception io) {
+                    LOG.error("Copy to library failed.", io);
+                }
+            });
 
         updateFromPrefs();
     }
 
     @Override
     public void onCreateContextMenu(ContextMenu menu, View v,
-                                    ContextMenu.ContextMenuInfo menuInfo) {
+        ContextMenu.ContextMenuInfo menuInfo) {
 
         // This is a hack to give the longclick handler time
         // to find the word the user long clicked on.
@@ -1289,43 +1289,43 @@ public class ReadingFragment extends RoboSherlockFragment implements
             final int endIndex = this.selectedWord.getEndOffset();
 
             String header = String.format(getString(R.string.word_select),
-                    selectedWord.getText() );
+                selectedWord.getText() );
 
             menu.setHeaderTitle(header);
 
             if (isDictionaryAvailable()) {
                 android.view.MenuItem item = menu
-                        .add(getString(R.string.dictionary_lookup));
+                    .add(getString(R.string.dictionary_lookup));
                 onMenuPress(item).thenDo( () -> lookupDictionary(word.toString()) );
             }
 
             menu.add(R.string.highlight).setOnMenuItemClickListener( item -> {
-                highLight( startIndex, endIndex, word.toString() );
-                return false;
-            });
+                    highLight( startIndex, endIndex, word.toString() );
+                    return false;
+                });
 
             android.view.MenuItem lookUpWikipediaItem = menu
-                    .add(getString(R.string.wikipedia_lookup));
+                .add(getString(R.string.wikipedia_lookup));
 
             onMenuPress(lookUpWikipediaItem).thenDo(
-                    () -> lookupWikipedia(word.toString()));
+                () -> lookupWikipedia(word.toString()));
 
 
             android.view.MenuItem lookUpWiktionaryItem = menu
-                    .add(getString(R.string.lookup_wiktionary));
+                .add(getString(R.string.lookup_wiktionary));
 
             lookUpWiktionaryItem.setOnMenuItemClickListener( item -> {
-                lookupWiktionary(word.toString());
-                return true;
-            });
+                    lookupWiktionary(word.toString());
+                    return true;
+                });
 
             android.view.MenuItem lookupGoogleItem = menu
-                    .add(getString(R.string.google_lookup));
+                .add(getString(R.string.google_lookup));
 
             lookupGoogleItem.setOnMenuItemClickListener( item -> {
-                lookupGoogle(word.toString());
-                return true;
-            });
+                    lookupGoogle(word.toString());
+                    return true;
+                });
 
             this.selectedWord = null;
         }
@@ -1339,7 +1339,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
         String text = TextUtil.shortenText( selectedText );
 
         this.highlightManager.registerHighlight(fileName, text, bookView.getIndex(),
-                pageStart + from, pageStart + to);
+            pageStart + from, pageStart + to);
 
         bookView.update();
     }
@@ -1350,25 +1350,25 @@ public class ReadingFragment extends RoboSherlockFragment implements
         editalert.setTitle(R.string.text_note);
         final EditText input = new EditText(context);
         LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
-                LinearLayout.LayoutParams.MATCH_PARENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT);
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT);
         input.setLayoutParams(lp);
         editalert.setView(input);
         input.setText( highLight.getTextNote() );
 
         editalert.setPositiveButton(R.string.save_note, (dialog, which) -> {
-            highLight.setTextNote(input.getText().toString());
-            bookView.update();
-            highlightManager.saveHighLights();
-        });
+                highLight.setTextNote(input.getText().toString());
+                bookView.update();
+                highlightManager.saveHighLights();
+            });
 
         editalert.setNegativeButton(android.R.string.cancel, (dialog,which) -> {} );
 
         editalert.setNeutralButton(R.string.clear_note, (dialog, which) -> {
-            highLight.setTextNote(null);
-            bookView.update();
-            highlightManager.saveHighLights();
-        });
+                highLight.setTextNote(null);
+                bookView.update();
+                highlightManager.saveHighLights();
+            });
 
         editalert.show();
     }
@@ -1376,19 +1376,19 @@ public class ReadingFragment extends RoboSherlockFragment implements
     private void showHighlightColourDialog( final HighLight highLight ) {
 
         AmbilWarnaDialog ambilWarnaDialog = new AmbilWarnaDialog(
-                context, highLight.getColor(), new AmbilWarnaDialog.OnAmbilWarnaListener() {
-            @Override
-            public void onCancel(AmbilWarnaDialog dialog) {
-                //do nothing.
-            }
+            context, highLight.getColor(), new AmbilWarnaDialog.OnAmbilWarnaListener() {
+                    @Override
+                    public void onCancel(AmbilWarnaDialog dialog) {
+                        //do nothing.
+                    }
 
-            @Override
-            public void onOk(AmbilWarnaDialog dialog, int color) {
-                highLight.setColor( color );
-                bookView.update();
-                highlightManager.saveHighLights();
-            }
-        });
+                    @Override
+                    public void onOk(AmbilWarnaDialog dialog, int color) {
+                        highLight.setColor( color );
+                        bookView.update();
+                        highlightManager.saveHighLights();
+                    }
+                });
 
         ambilWarnaDialog.show();
     }
@@ -1396,14 +1396,14 @@ public class ReadingFragment extends RoboSherlockFragment implements
     private void onBookmarkLongClick(final Bookmark bookmark) {
 
         actionModeBuilderProvider.get()
-                .setTitle(R.string.bookmark_options)
-                .setOnCreateAction((actionMode, menu) -> {
+            .setTitle(R.string.bookmark_options)
+            .setOnCreateAction((actionMode, menu) -> {
                     MenuItem delete = menu.add(R.string.delete);
                     delete.setIcon(R.drawable.trash_can);
 
                     return true;
                 })
-                .setOnActionItemClickedAction((actionMode, menuItem) -> {
+            .setOnActionItemClickedAction((actionMode, menuItem) -> {
 
                     boolean result = false;
 
@@ -1419,7 +1419,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
                     return result;
                 })
-                .build(getSherlockActivity());
+            .build(getSherlockActivity());
     }
 
     @Override
@@ -1433,14 +1433,14 @@ public class ReadingFragment extends RoboSherlockFragment implements
         commands.put( getString(R.string.set_colour), this::showHighlightColourDialog );
 
         actionModeBuilderProvider.get()
-                .setTitle(R.string.highlight_options)
-                .setOnCreateAction((actionMode, menu) -> {
+            .setTitle(R.string.highlight_options)
+            .setOnCreateAction((actionMode, menu) -> {
                     menu.add(R.string.edit).setIcon(R.drawable.edit);
                     menu.add(R.string.set_colour).setIcon(R.drawable.color);
                     menu.add(R.string.delete).setIcon(R.drawable.trash_can);
                     return true;
                 })
-                .setOnActionItemClickedAction((actionMode, menuItem) -> {
+            .setOnActionItemClickedAction((actionMode, menuItem) -> {
 
                     Command<HighLight> cmd = commands.get(menuItem.getTitle());
 
@@ -1453,21 +1453,21 @@ public class ReadingFragment extends RoboSherlockFragment implements
                     return false;
 
                 })
-                .build(getSherlockActivity());
+            .build(getSherlockActivity());
     }
 
     private void deleteHightlight( final HighLight highLight ) {
 
         if ( highLight.getTextNote() != null && highLight.getTextNote().length() > 0 ) {
             new AlertDialog.Builder(context)
-                    .setMessage( R.string.notes_attached )
-                    .setNegativeButton(android.R.string.no, (a, b) -> {})
-                    .setPositiveButton(android.R.string.yes, (dialogInterface, i) -> {
+                .setMessage( R.string.notes_attached )
+                .setNegativeButton(android.R.string.no, (a, b) -> {})
+                .setPositiveButton(android.R.string.yes, (dialogInterface, i) -> {
                         highlightManager.removeHighLight(highLight);
                         Toast.makeText( context,R.string.highlight_deleted, Toast.LENGTH_SHORT ).show();
                         bookView.update();
-                    })
-                    .show();
+                })
+                .show();
         } else {
             highlightManager.removeHighLight(highLight);
             Toast.makeText( context,R.string.highlight_deleted, Toast.LENGTH_SHORT ).show();
@@ -1499,12 +1499,12 @@ public class ReadingFragment extends RoboSherlockFragment implements
     public void lookupWikipedia(String text) {
 
         openBrowser("http://" + getLanguageCode() + ".wikipedia.org/wiki/Special:Search?search="
-                + URLEncoder.encode(text));
+            + URLEncoder.encode(text));
     }
 
     public void lookupWiktionary(String text) {
         openBrowser("http://" + getLanguageCode() + ".wiktionary.org/w/index.php?title=Special%3ASearch&search="
-                + URLEncoder.encode(text));
+            + URLEncoder.encode(text));
 
     }
 
@@ -1570,9 +1570,9 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
             NotificationCompat.Builder builder = new NotificationCompat.Builder(readingActivity);
             builder.setContentTitle(getString(R.string.app_name))
-                    .setContentText(errorMessage)
-                    .setSmallIcon(R.drawable.cross)
-                    .setAutoCancel( true );
+                .setContentText(errorMessage)
+                .setSmallIcon(R.drawable.cross)
+                .setAutoCancel( true );
 
             builder.setTicker(errorMessage);
             PendingIntent pendingIntent = PendingIntent.getActivity( readingActivity, 0, new Intent(), 0);
@@ -1686,14 +1686,14 @@ public class ReadingFragment extends RoboSherlockFragment implements
         }
 
         switch (rotation) {
-            case Surface.ROTATION_0:
-            case Surface.ROTATION_90:
-                invert = false;
-                break;
-            case Surface.ROTATION_180:
-            case Surface.ROTATION_270:
-                invert = true;
-                break;
+        case Surface.ROTATION_0:
+        case Surface.ROTATION_90:
+            invert = false;
+            break;
+        case Surface.ROTATION_180:
+        case Surface.ROTATION_270:
+            invert = true;
+            break;
         }
 
         if (event.getAction() != KeyEvent.ACTION_DOWN) {
@@ -1729,19 +1729,19 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
         switch (keyCode) {
 
-            case KeyEvent.KEYCODE_MEDIA_PLAY:
-            case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
-            case KeyEvent.KEYCODE_MEDIA_PAUSE:
-                return simulateButtonPress(action, R.id.playPauseButton, playPauseButton);
+        case KeyEvent.KEYCODE_MEDIA_PLAY:
+        case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
+        case KeyEvent.KEYCODE_MEDIA_PAUSE:
+            return simulateButtonPress(action, R.id.playPauseButton, playPauseButton);
 
-            case KeyEvent.KEYCODE_MEDIA_STOP:
-                return simulateButtonPress(action, R.id.stopButton, stopButton );
+        case KeyEvent.KEYCODE_MEDIA_STOP:
+            return simulateButtonPress(action, R.id.stopButton, stopButton );
 
-            case KeyEvent.KEYCODE_MEDIA_NEXT:
-                return simulateButtonPress(action, R.id.nextButton, nextButton );
+        case KeyEvent.KEYCODE_MEDIA_NEXT:
+            return simulateButtonPress(action, R.id.nextButton, nextButton );
 
-            case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
-                return simulateButtonPress(action, R.id.prevButton, prevButton );
+        case KeyEvent.KEYCODE_MEDIA_PREVIOUS:
+            return simulateButtonPress(action, R.id.prevButton, prevButton );
         }
 
         return false;
@@ -1786,15 +1786,15 @@ public class ReadingFragment extends RoboSherlockFragment implements
             return true;
         }
 
-		/*
-		 * Tricky bit of code here: if we are NOT running TTS,
-		 * we want to be able to start it using the play/pause button.
-		 *
-		 * When we ARE running TTS, we'll get every media event twice:
-		 * once through the receiver and once here if focused.
-		 *
-		 * So, we only try to read media events here if tts is running.
-		 */
+        /*
+         * Tricky bit of code here: if we are NOT running TTS,
+         * we want to be able to start it using the play/pause button.
+         *
+         * When we ARE running TTS, we'll get every media event twice:
+         * once through the receiver and once here if focused.
+         *
+         * So, we only try to read media events here if tts is running.
+         */
         if ( ! ttsIsRunning() && dispatchMediaKeyEvent(event) ) {
             return true;
         }
@@ -1803,52 +1803,52 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
         switch (keyCode) {
 
-            case KeyEvent.KEYCODE_VOLUME_DOWN:
-            case KeyEvent.KEYCODE_VOLUME_UP:
-                return handleVolumeButtonEvent(event);
+        case KeyEvent.KEYCODE_VOLUME_DOWN:
+        case KeyEvent.KEYCODE_VOLUME_UP:
+            return handleVolumeButtonEvent(event);
 
-            case KeyEvent.KEYCODE_DPAD_RIGHT:
-                if (action == KeyEvent.ACTION_DOWN) {
-                    pageDown(Orientation.HORIZONTAL);
+        case KeyEvent.KEYCODE_DPAD_RIGHT:
+            if (action == KeyEvent.ACTION_DOWN) {
+                pageDown(Orientation.HORIZONTAL);
+            }
+
+            return true;
+
+        case KeyEvent.KEYCODE_DPAD_LEFT:
+            if (action == KeyEvent.ACTION_DOWN) {
+                pageUp(Orientation.HORIZONTAL);
+            }
+
+            return true;
+
+        case KeyEvent.KEYCODE_BACK:
+            if (action == KeyEvent.ACTION_DOWN) {
+
+                if (titleBarLayout.getVisibility() == View.VISIBLE) {
+                    hideTitleBar();
+                    updateFromPrefs();
+                    return true;
+                } else if (bookView.hasPrevPosition()) {
+                    bookView.goBackInHistory();
+                    return true;
                 }
+            }
 
-                return true;
+            return false;
 
-            case KeyEvent.KEYCODE_DPAD_LEFT:
-                if (action == KeyEvent.ACTION_DOWN) {
-                    pageUp(Orientation.HORIZONTAL);
-                }
 
-                return true;
-
-            case KeyEvent.KEYCODE_BACK:
-                if (action == KeyEvent.ACTION_DOWN) {
-
-                    if (titleBarLayout.getVisibility() == View.VISIBLE) {
-                        hideTitleBar();
-                        updateFromPrefs();
-                        return true;
-                    } else if (bookView.hasPrevPosition()) {
-                        bookView.goBackInHistory();
-                        return true;
-                    }
-                }
-
+        case KEYCODE_NOOK_TOUCH_BUTTON_LEFT_TOP:
+        case KEYCODE_NOOK_TOUCH_BUTTON_RIGHT_TOP:
+            nook_touch_up_press = true;
+        case KEYCODE_NOOK_TOUCH_BUTTON_LEFT_BOTTOM:
+        case KEYCODE_NOOK_TOUCH_BUTTON_RIGHT_BOTTOM:
+            if(action == KeyEvent.ACTION_UP)
                 return false;
-
-
-            case KEYCODE_NOOK_TOUCH_BUTTON_LEFT_TOP:
-            case KEYCODE_NOOK_TOUCH_BUTTON_RIGHT_TOP:
-                nook_touch_up_press = true;
-            case KEYCODE_NOOK_TOUCH_BUTTON_LEFT_BOTTOM:
-            case KEYCODE_NOOK_TOUCH_BUTTON_RIGHT_BOTTOM:
-                if(action == KeyEvent.ACTION_UP)
-                    return false;
-                if(nook_touch_up_press == config.isNookUpButtonForward())
-                    pageDown(Orientation.HORIZONTAL);
-                else
-                    pageUp(Orientation.HORIZONTAL);
-                return true;
+            if(nook_touch_up_press == config.isNookUpButtonForward())
+                pageDown(Orientation.HORIZONTAL);
+            else
+                pageUp(Orientation.HORIZONTAL);
+            return true;
         }
 
 
@@ -1938,12 +1938,12 @@ public class ReadingFragment extends RoboSherlockFragment implements
         }
 
         after.forEach(img -> {
-            PageTimer timer = new PageTimer(img, pageNumberView.getHeight());
+                PageTimer timer = new PageTimer(img, pageNumberView.getHeight());
 
-            timer.setSpeed(config.getScrollSpeed());
+                timer.setSpeed(config.getScrollSpeed());
 
-            dummyView.setAnimator(timer);
-        });
+                dummyView.setAnimator(timer);
+            });
     }
 
     private void doPageCurl(boolean flipRight, boolean pageDown) {
@@ -2051,11 +2051,11 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
         try {
             Bitmap bitmap = Bitmap.createBitmap(viewSwitcher.getWidth(),
-                    viewSwitcher.getHeight(), Config.ARGB_8888);
+                viewSwitcher.getHeight(), Config.ARGB_8888);
             Canvas canvas = new Canvas(bitmap);
 
             bookView.layout(0, 0, viewSwitcher.getWidth(),
-                    viewSwitcher.getHeight());
+                viewSwitcher.getHeight());
 
             bookView.draw(canvas);
 
@@ -2068,16 +2068,16 @@ public class ReadingFragment extends RoboSherlockFragment implements
                  */
 
                 Bitmap pageNumberBitmap = Bitmap.createBitmap(
-                        pageNumberView.getWidth(), pageNumberView.getHeight(),
-                        Config.ARGB_8888);
+                    pageNumberView.getWidth(), pageNumberView.getHeight(),
+                    Config.ARGB_8888);
                 Canvas pageNumberCanvas = new Canvas(pageNumberBitmap);
 
                 pageNumberView.layout(0, 0, pageNumberView.getWidth(),
-                        pageNumberView.getHeight());
+                    pageNumberView.getHeight());
                 pageNumberView.draw(pageNumberCanvas);
 
                 canvas.drawBitmap(pageNumberBitmap, 0, viewSwitcher.getHeight()
-                        - pageNumberView.getHeight(), new Paint());
+                    - pageNumberView.getHeight(), new Paint());
 
                 pageNumberBitmap.recycle();
 
@@ -2094,9 +2094,9 @@ public class ReadingFragment extends RoboSherlockFragment implements
     private void prepareSlide(Animation inAnim, Animation outAnim) {
 
         Option<Bitmap> bitmap = getBookViewSnapshot();
-		/*
-		TODO: is this OK?
-        We don't set anything when we get None instead of Some.
+        /*
+          TODO: is this OK?
+          We don't set anything when we get None instead of Some.
         */
         bitmap.forEach( dummyView::setImageBitmap );
 
@@ -2104,20 +2104,20 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
         inAnim.setAnimationListener(new Animation.AnimationListener() {
 
-            public void onAnimationStart(Animation animation) {}
+                public void onAnimationStart(Animation animation) {}
 
-            public void onAnimationRepeat(Animation animation) {}
+                public void onAnimationRepeat(Animation animation) {}
 
-            @Override
-            public void onAnimationEnd(Animation animation) {
-                onSlideFinished();
-            }
-        });
+                @Override
+                public void onAnimationEnd(Animation animation) {
+                    onSlideFinished();
+                }
+            });
 
         viewSwitcher.layout(0, 0, viewSwitcher.getWidth(),
-                viewSwitcher.getHeight());
+            viewSwitcher.getHeight());
         dummyView.layout(0, 0, viewSwitcher.getWidth(),
-                viewSwitcher.getHeight());
+            viewSwitcher.getHeight());
 
         this.viewSwitcher.showNext();
 
@@ -2150,10 +2150,10 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
                 if ( direction == ReadingDirection.LEFT_TO_RIGHT ) {
                     prepareSlide(Animations.inFromRightAnimation(),
-                            Animations.outToLeftAnimation());
+                        Animations.outToLeftAnimation());
                 } else {
                     prepareSlide(Animations.inFromLeftAnimation(),
-                            Animations.outToRightAnimation());
+                        Animations.outToRightAnimation());
                 }
 
                 viewSwitcher.showNext();
@@ -2165,7 +2165,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
         } else {
             if (config.getVerticalAnim() == AnimationStyle.SLIDE) {
                 prepareSlide(Animations.inFromBottomAnimation(),
-                        Animations.outToTopAnimation());
+                    Animations.outToTopAnimation());
                 viewSwitcher.showNext();
             }
 
@@ -2192,10 +2192,10 @@ public class ReadingFragment extends RoboSherlockFragment implements
             } else if (animH == AnimationStyle.SLIDE) {
                 if ( direction == ReadingDirection.LEFT_TO_RIGHT ) {
                     prepareSlide(Animations.inFromLeftAnimation(),
-                            Animations.outToRightAnimation());
+                        Animations.outToRightAnimation());
                 } else {
                     prepareSlide(Animations.inFromRightAnimation(),
-                            Animations.outToLeftAnimation());
+                        Animations.outToLeftAnimation());
                 }
                 viewSwitcher.showNext();
                 bookView.pageUp();
@@ -2207,7 +2207,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
             if (config.getVerticalAnim() == AnimationStyle.SLIDE) {
                 prepareSlide(Animations.inFromTopAnimation(),
-                        Animations.outToBottomAnimation());
+                    Animations.outToBottomAnimation());
                 viewSwitcher.showNext();
             }
 
@@ -2250,7 +2250,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
         }
 
         activity.getWindow().addFlags(
-                WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+            WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
         activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
     }
 
@@ -2338,7 +2338,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
         if ( pageNumber != -1 ) {
             text = text + String.format( getString(R.string.page_number_of),
-                    pageNumber, totalPages ) + " (" + progressPercentage + "%)\n\n";
+                pageNumber, totalPages ) + " (" + progressPercentage + "%)\n\n";
 
         } else {
             text += "" + progressPercentage + "%\n\n";
@@ -2363,36 +2363,36 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
         if (this.searchMenuItem != null) {
             final com.actionbarsherlock.widget.SearchView searchView =
-                    (com.actionbarsherlock.widget.SearchView) searchMenuItem.getActionView();
+                (com.actionbarsherlock.widget.SearchView) searchMenuItem.getActionView();
 
             if (searchView != null) {
 
                 searchView.setSubmitButtonEnabled(true);
                 searchView.setOnQueryTextListener(new com.actionbarsherlock.widget.SearchView.OnQueryTextListener() {
 
-                    //This is a work-around, since we get the onQuerySubmit() event twice
-                    //when the user hits enter
-                    private String lastQuery = "";
+                        //This is a work-around, since we get the onQuerySubmit() event twice
+                        //when the user hits enter
+                        private String lastQuery = "";
 
-                    @Override
-                    public boolean onQueryTextSubmit(String query) {
+                        @Override
+                        public boolean onQueryTextSubmit(String query) {
 
-                        if ( query.equals(lastQuery) && searchResults != null ) {
-                            showSearchResultDialog(searchResults);
-                        } else if ( ! query.equals(lastQuery) ) {
-                            searchResults = null;
-                            lastQuery = query;
-                            performSearch(query);
+                            if ( query.equals(lastQuery) && searchResults != null ) {
+                                showSearchResultDialog(searchResults);
+                            } else if ( ! query.equals(lastQuery) ) {
+                                searchResults = null;
+                                lastQuery = query;
+                                performSearch(query);
+                            }
+
+                            return true;
                         }
 
-                        return true;
-                    }
-
-                    @Override
-                    public boolean onQueryTextChange(String newText) {
-                        return false;
-                    }
-                } );
+                        @Override
+                        public boolean onQueryTextChange(String newText) {
+                            return false;
+                        }
+                    } );
             }
         }
     }
@@ -2411,68 +2411,68 @@ public class ReadingFragment extends RoboSherlockFragment implements
         // Handle item selection
         switch (item.getItemId()) {
 
-            case R.id.profile_night:
-                config.setColourProfile(ColourProfile.NIGHT);
-                this.restartActivity();
-                return true;
+        case R.id.profile_night:
+            config.setColourProfile(ColourProfile.NIGHT);
+            this.restartActivity();
+            return true;
 
-            case R.id.profile_day:
-                config.setColourProfile(ColourProfile.DAY);
-                this.restartActivity();
-                return true;
+        case R.id.profile_day:
+            config.setColourProfile(ColourProfile.DAY);
+            this.restartActivity();
+            return true;
 
-            case R.id.manual_sync:
-                if (config.isSyncEnabled()) {
-                    new ManualProgressSync().execute();
-                } else {
-                    Toast.makeText(context, R.string.enter_email, Toast.LENGTH_LONG)
-                            .show();
-                }
-                return true;
+        case R.id.manual_sync:
+            if (config.isSyncEnabled()) {
+                new ManualProgressSync().execute();
+            } else {
+                Toast.makeText(context, R.string.enter_email, Toast.LENGTH_LONG)
+                    .show();
+            }
+            return true;
 
-            case R.id.search_text:
-                onSearchRequested();
-                return true;
+        case R.id.search_text:
+            onSearchRequested();
+            return true;
 
-            case R.id.open_file:
-                launchFileManager();
-                return true;
+        case R.id.open_file:
+            launchFileManager();
+            return true;
 
-            case R.id.rolling_blind:
-                startAutoScroll();
-                return true;
+        case R.id.rolling_blind:
+            startAutoScroll();
+            return true;
 
-            case R.id.text_to_speech:
-                startTextToSpeech();
-                return true;
+        case R.id.text_to_speech:
+            startTextToSpeech();
+            return true;
 
-            case R.id.about:
-                dialogFactory.buildAboutDialog().show();
-                return true;
+        case R.id.about:
+            dialogFactory.buildAboutDialog().show();
+            return true;
 
-            case R.id.add_bookmark:
-                FragmentTransaction ft = getFragmentManager().beginTransaction();
-                ft.addToBackStack(null);
-                AddBookmarkFragment fragment = new AddBookmarkFragment();
+        case R.id.add_bookmark:
+            FragmentTransaction ft = getFragmentManager().beginTransaction();
+            ft.addToBackStack(null);
+            AddBookmarkFragment fragment = new AddBookmarkFragment();
 
-                fragment.setFilename(this.fileName);
-                fragment.setBookmarkDatabaseHelper(bookmarkDatabaseHelper);
-                fragment.setBookIndex(this.bookView.getIndex());
-                fragment.setBookPosition(this.bookView.getProgressPosition());
+            fragment.setFilename(this.fileName);
+            fragment.setBookmarkDatabaseHelper(bookmarkDatabaseHelper);
+            fragment.setBookIndex(this.bookView.getIndex());
+            fragment.setBookPosition(this.bookView.getProgressPosition());
 
-                String firstLine = this.bookView.getFirstLine();
+            String firstLine = this.bookView.getFirstLine();
 
-                if ( firstLine.length() > 20 ) {
-                    firstLine = firstLine.substring(0, 20) + "…";
-                }
+            if ( firstLine.length() > 20 ) {
+                firstLine = firstLine.substring(0, 20) + "…";
+            }
 
-                fragment.setInitialText( firstLine );
+            fragment.setInitialText( firstLine );
 
-                fragment.show(ft, "dialog");
-                return true;
+            fragment.show(ft, "dialog");
+            return true;
 
-            default:
-                return super.onOptionsItemSelected(item);
+        default:
+            return super.onOptionsItemSelected(item);
         }
     }
 
@@ -2518,7 +2518,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
             getSherlockActivity().getSupportActionBar().show();
             activity.getWindow().addFlags(
-                    WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
+                WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
             activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
         }
     }
@@ -2624,8 +2624,8 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
             if (brightnessToast == null) {
                 brightnessToast = Toast
-                        .makeText(context, brightness + ": "
-                                + brightnessLevel, Toast.LENGTH_SHORT);
+                    .makeText(context, brightness + ": "
+                        + brightnessLevel, Toast.LENGTH_SHORT);
             } else {
                 brightnessToast.setText(brightness + ": " + brightnessLevel);
             }
@@ -2668,7 +2668,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
         } catch (ActivityNotFoundException e) {
             // No compatible file manager was found.
             Toast.makeText(context, getString(R.string.install_oi),
-                    Toast.LENGTH_SHORT).show();
+                Toast.LENGTH_SHORT).show();
         }
     }
 
@@ -2694,14 +2694,14 @@ public class ReadingFragment extends RoboSherlockFragment implements
     public List<NavigationCallback> getTableOfContents() {
 
         List<TocEntry> entries = this.bookView.getTableOfContents()
-                .getOrElse(new ArrayList<>());
+            .getOrElse(new ArrayList<>());
 
         return map( entries, tocEntry ->
-                        new NavigationCallback(
-                                tocEntry.getTitle(), "",
-                                () -> bookView.navigateTo(tocEntry)
-                        )
-        );
+            new NavigationCallback(
+                tocEntry.getTitle(), "",
+                () -> bookView.navigateTo(tocEntry)
+                                   )
+                    );
 
     }
 
@@ -2718,15 +2718,15 @@ public class ReadingFragment extends RoboSherlockFragment implements
         libraryService.updateReadingProgress(fileName, progressPercentage);
 
         backgroundHandler.post( () -> {
-            try {
-                progressService.storeProgress(fileName,
+                try {
+                    progressService.storeProgress(fileName,
                         index, position,
                         progressPercentage);
-            } catch (Exception e) {
-                LOG.error("Error saving progress", e);
-            }
+                } catch (Exception e) {
+                    LOG.error("Error saving progress", e);
+                }
 
-        });
+            });
     }
 
     public void performSearch(String query) {
@@ -2746,59 +2746,59 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
         task.setOnPreExecute( () -> {
 
-            searchProgress.setMessage(getString(R.string.search_wait));
-            searchProgress.show();
+                searchProgress.setMessage(getString(R.string.search_wait));
+                searchProgress.show();
 
-            // Hide on-screen keyboard if it is showing
-            InputMethodManager imm = (InputMethodManager) context.getSystemService(Activity.INPUT_METHOD_SERVICE);
-            imm.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0);
+                // Hide on-screen keyboard if it is showing
+                InputMethodManager imm = (InputMethodManager) context.getSystemService(Activity.INPUT_METHOD_SERVICE);
+                imm.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0);
 
-        });
+            });
 
         task.setOnProgressUpdate( (values) -> {
 
-            if ( isAdded() ) {
+                if ( isAdded() ) {
 
-                LOG.debug("Found match at index=" + values[0].getIndex()
+                    LOG.debug("Found match at index=" + values[0].getIndex()
                         + ", offset=" + values[0].getStart() + " with context "
                         + values[0].getDisplay());
-                SearchResult res = values[0];
+                    SearchResult res = values[0];
 
-                if (res.getDisplay() != null) {
-                    counter[0] = counter[0] + 1;
-                    String update = String.format(
+                    if (res.getDisplay() != null) {
+                        counter[0] = counter[0] + 1;
+                        String update = String.format(
                             getString(R.string.search_hits), counter[0]);
-                    searchProgress.setMessage(update);
-                }
+                        searchProgress.setMessage(update);
+                    }
 
-                searchProgress.setProgress(bookView.getPercentageFor(res.getIndex(), res.getStart()));
-            }
-        });
+                    searchProgress.setProgress(bookView.getPercentageFor(res.getIndex(), res.getStart()));
+                }
+            });
 
         task.setOnCancelled( (result) -> {
-            if ( isAdded() ) {
-                Toast.makeText(context, R.string.search_cancelled,
+                if ( isAdded() ) {
+                    Toast.makeText(context, R.string.search_cancelled,
                         Toast.LENGTH_LONG).show();
-            }
-        });
+                }
+            });
 
         task.setOnPostExecute( (result) -> {
-            searchProgress.dismiss();
+                searchProgress.dismiss();
 
-            if (!task.isCancelled() && isAdded() ) {
+                if (!task.isCancelled() && isAdded() ) {
 
-                List<SearchResult> resultList = result.getOrElse( new ArrayList<>() );
+                    List<SearchResult> resultList = result.getOrElse( new ArrayList<>() );
 
-                if (resultList.size() > 0) {
-                    searchResults = resultList;
-                    showSearchResultDialog(resultList);
-                } else {
-                    Toast.makeText(context,
+                    if (resultList.size() > 0) {
+                        searchResults = resultList;
+                        showSearchResultDialog(resultList);
+                    } else {
+                        Toast.makeText(context,
                             R.string.search_no_matches, Toast.LENGTH_LONG)
                             .show();
+                    }
                 }
-            }
-        });
+            });
 
         searchProgress.setOnCancelListener( dialog -> task.cancel(true) );
         executeTask( task, query );
@@ -2838,7 +2838,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
     private boolean isSearchResultsDialogShowing = false;
 
     private void showSearchResultDialog(
-            final List<SearchResult> results) {
+        final List<SearchResult> results) {
 
         if ( isSearchResultsDialogShowing ) {
             return;
@@ -2881,14 +2881,14 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
             if ( pageNumber != -1 ) {
                 text = String.format( context.getString(R.string.page_number_of),
-                        pageNumber, totalNumberOfPages )
-                        + " (" + percentage + "%)";
+                    pageNumber, totalNumberOfPages )
+                    + " (" + percentage + "%)";
             } else {
                 text = percentage + "%";
             }
 
             NavigationCallback callback = new NavigationCallback( searchResult.getDisplay(), text )
-                    .setOnClick( () -> bookView.navigateBySearchResult( searchResult ));
+                .setOnClick( () -> bookView.navigateBySearchResult( searchResult ));
 
             result.add( callback );
         }
@@ -2922,8 +2922,8 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
         if ( pageNumber != -1 ) {
             result = String.format( context.getString(R.string.page_number_of),
-                    pageNumber, totalNumberOfPages )
-                    + " (" + percentage + "%)";
+                pageNumber, totalNumberOfPages )
+                + " (" + percentage + "%)";
         }
 
         if ( text != null && text.trim().length() > 0 ) {
@@ -2942,11 +2942,11 @@ public class ReadingFragment extends RoboSherlockFragment implements
         for ( final Bookmark bookmark: bookmarks ) {
 
             final String finalText = getHighlightLabel( bookmark.getIndex(),
-                    bookmark.getPosition(), null );
+                bookmark.getPosition(), null );
 
             NavigationCallback callback = new NavigationCallback( bookmark.getName(), finalText )
-                    .setOnClick( () -> bookView.navigateTo( bookmark.getIndex(), bookmark.getPosition() ))
-                    .setOnLongClick( () -> onBookmarkLongClick(bookmark) );
+                .setOnClick( () -> bookView.navigateTo( bookmark.getIndex(), bookmark.getPosition() ))
+                .setOnLongClick( () -> onBookmarkLongClick(bookmark) );
 
             result.add( callback );
         }
@@ -2964,11 +2964,11 @@ public class ReadingFragment extends RoboSherlockFragment implements
         for ( final HighLight highLight: highLights ) {
 
             final String finalText = getHighlightLabel( highLight.getIndex(), highLight.getStart(),
-                    highLight.getTextNote() );
+                highLight.getTextNote() );
 
             NavigationCallback callback = new NavigationCallback( highLight.getDisplayText(), finalText )
-                    .setOnClick( () -> bookView.navigateTo( highLight.getIndex(), highLight.getStart() ))
-                    .setOnLongClick( () -> onHighLightClick(highLight) );
+                .setOnClick( () -> bookView.navigateTo( highLight.getIndex(), highLight.getStart() ))
+                .setOnLongClick( () -> onHighLightClick(highLight) );
 
             result.add( callback );
 
@@ -2978,7 +2978,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
     }
 
     private class ManualProgressSync extends
-            AsyncTask<None, Integer, Option<List<BookProgress>>> {
+                                         AsyncTask<None, Integer, Option<List<BookProgress>>> {
 
         private boolean accessDenied = false;
 
@@ -3041,7 +3041,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
     }
 
     private class DownloadProgressTask extends
-            AsyncTask<None, Integer, Option<BookProgress>> {
+                                           AsyncTask<None, Integer, Option<BookProgress>> {
 
         @Override
         protected void onPreExecute() {
@@ -3050,10 +3050,10 @@ public class ReadingFragment extends RoboSherlockFragment implements
                 progressDialog.setMessage(getString(R.string.syncing));
                 progressDialog.setCancelable(true);
                 progressDialog.setOnCancelListener( d -> {
-                    DownloadProgressTask.this.cancel(true);
-                    progressDialog.setMessage( getString( R.string.cancelling) );
-                    progressDialog.show();
-                });
+                        DownloadProgressTask.this.cancel(true);
+                        progressDialog.setMessage( getString( R.string.cancelling) );
+                        progressDialog.show();
+                    });
 
                 progressDialog.show();
             }
@@ -3068,7 +3068,7 @@ public class ReadingFragment extends RoboSherlockFragment implements
         protected Option<BookProgress> doInBackground(None... params) {
             try {
                 Option<List<BookProgress>> updates = progressService
-                        .getProgress(fileName);
+                    .getProgress(fileName);
 
                 return firstOption( updates.getOrElse( new ArrayList<>() ) );
 
@@ -3084,17 +3084,17 @@ public class ReadingFragment extends RoboSherlockFragment implements
             closeWaitDialog();
 
             progress.forEach( p -> {
-                int index = bookView.getIndex();
-                int pos = bookView.getProgressPosition();
+                    int index = bookView.getIndex();
+                    int pos = bookView.getProgressPosition();
 
-                if (p.getIndex() > index) {
-                    bookView.setIndex(p.getIndex());
-                    bookView.setPosition(p.getProgress());
-                } else if (p.getIndex() == index) {
-                    pos = Math.max(pos, p.getProgress());
-                    bookView.setPosition(pos);
-                }
-            });
+                    if (p.getIndex() > index) {
+                        bookView.setIndex(p.getIndex());
+                        bookView.setPosition(p.getProgress());
+                    } else if (p.getIndex() == index) {
+                        pos = Math.max(pos, p.getProgress());
+                        bookView.setPosition(pos);
+                    }
+                });
 
             bookView.restore();
         }
@@ -3111,8 +3111,8 @@ public class ReadingFragment extends RoboSherlockFragment implements
 
             if ( intent.getAction().equals(MediaButtonReceiver.INTENT_PAGETURNER_MEDIA)) {
                 KeyEvent event = new KeyEvent(
-                        intent.getIntExtra("action", 0),
-                        intent.getIntExtra("keyCode", 0));
+                    intent.getIntExtra("action", 0),
+                    intent.getIntExtra("keyCode", 0));
                 dispatchMediaKeyEvent(event);
             }
         }

--- a/src/net/nightwhistler/pageturner/library/Author.java
+++ b/src/net/nightwhistler/pageturner/library/Author.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -23,32 +23,32 @@ import java.util.Locale;
 
 public class Author implements Serializable {
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = -9027442126212861173L;
-	
-	private String firstName;
-	private String lastName;
-	
-	private String authorKey;
-	
-	public Author(String firstName, String lastName ) {
-		this.firstName = firstName;
-		this.lastName = lastName;
-		
-		this.authorKey = firstName.toLowerCase(Locale.US) + "_" + lastName.toLowerCase(Locale.US); 
-	}
-	
-	public String getAuthorKey() {
-		return authorKey;
-	}
-	
-	public String getFirstName() {
-		return firstName;
-	}
-	
-	public String getLastName() {
-		return lastName;
-	}
+    /**
+     *
+     */
+    private static final long serialVersionUID = -9027442126212861173L;
+
+    private String firstName;
+    private String lastName;
+
+    private String authorKey;
+
+    public Author(String firstName, String lastName ) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+
+        this.authorKey = firstName.toLowerCase(Locale.US) + "_" + lastName.toLowerCase(Locale.US);
+    }
+
+    public String getAuthorKey() {
+        return authorKey;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
 }

--- a/src/net/nightwhistler/pageturner/library/ImportCallback.java
+++ b/src/net/nightwhistler/pageturner/library/ImportCallback.java
@@ -23,11 +23,11 @@ import java.util.List;
 
 public interface ImportCallback {
 
-	void importComplete( int booksImported, List<String> failures, boolean emptyLibrary, boolean silent );
-	
-	void importStatusUpdate( String update, boolean silent );
-		
-	void importFailed( String reason, boolean silent );
+    void importComplete( int booksImported, List<String> failures, boolean emptyLibrary, boolean silent );
+
+    void importStatusUpdate( String update, boolean silent );
+
+    void importFailed( String reason, boolean silent );
 
     void importCancelled( int booksImported, List<String> failures, boolean emptyLibrary, boolean silent );
 

--- a/src/net/nightwhistler/pageturner/library/ImportTask.java
+++ b/src/net/nightwhistler/pageturner/library/ImportTask.java
@@ -39,46 +39,46 @@ import java.io.File;
 import java.util.*;
 
 public class ImportTask extends QueueableAsyncTask<File, Integer, Void> implements OnCancelListener {
-	
-	private Context context;
-	private LibraryService libraryService;
-	private ImportCallback callBack;
-	private Configuration config;
-	
-	private boolean copyToLibrary;
-	
-	private List<String> errors = new ArrayList<>();
-	
-	private static final Logger LOG = LoggerFactory.getLogger(ImportTask.class);
-	
-	private static final int UPDATE_FOLDER = 1;
-	private static final int UPDATE_IMPORT = 2;
-	
-	private int foldersScanned = 0;
-	private int booksImported = 0;
+
+    private Context context;
+    private LibraryService libraryService;
+    private ImportCallback callBack;
+    private Configuration config;
+
+    private boolean copyToLibrary;
+
+    private List<String> errors = new ArrayList<>();
+
+    private static final Logger LOG = LoggerFactory.getLogger(ImportTask.class);
+
+    private static final int UPDATE_FOLDER = 1;
+    private static final int UPDATE_IMPORT = 2;
+
+    private int foldersScanned = 0;
+    private int booksImported = 0;
 
     private boolean emptyLibrary;
     private boolean silent;
-	
-	private String importFailed = null;
-	
-	public ImportTask( Context context, LibraryService libraryService,
-			ImportCallback callBack, Configuration config, boolean copyToLibrary,
-            boolean silent) {
 
-		this.context = context;
-		this.libraryService = libraryService;
-		this.callBack = callBack;
-		this.copyToLibrary = copyToLibrary;
-		this.config = config;
+    private String importFailed = null;
+
+    public ImportTask( Context context, LibraryService libraryService,
+        ImportCallback callBack, Configuration config, boolean copyToLibrary,
+        boolean silent) {
+
+        this.context = context;
+        this.libraryService = libraryService;
+        this.callBack = callBack;
+        this.copyToLibrary = copyToLibrary;
+        this.config = config;
         this.silent = silent;
-	}		
-	
-	@Override
-	public void onCancel(DialogInterface dialog) {
-		LOG.debug("User aborted import.");	
-		requestCancellation();
-	}
+    }
+
+    @Override
+    public void onCancel(DialogInterface dialog) {
+        LOG.debug("User aborted import.");
+        requestCancellation();
+    }
 
     public boolean isSilent() {
         return this.silent;
@@ -89,21 +89,21 @@ public class ImportTask extends QueueableAsyncTask<File, Integer, Void> implemen
     }
 
     @Override
-	public Option<Void> doInBackground(File... params) {
+    public Option<Void> doInBackground(File... params) {
 
         doInBackground( params[0] );
 
-		return new None();
-	}
+        return new None();
+    }
 
     private void doInBackground(File parent) {
 
         LOG.debug( "Starting import of folder " + parent.getAbsolutePath() );
 
         /*
-        Hack: don't run automated import on an empty database, since we explicitly ask
-        the user to import.
-         */
+          Hack: don't run automated import on an empty database, since we explicitly ask
+          the user to import.
+        */
         if ( silent && libraryService.findAllByTitle(null).getSize() == 0 ) {
             return;
         }
@@ -141,12 +141,12 @@ public class ImportTask extends QueueableAsyncTask<File, Integer, Void> implemen
         }
 
     }
-	
-	private void findEpubsInFolder( File folder, List<File> items) {
-		
-		if ( folder == null  || ! folder.exists() ) {
-			return;
-		}
+
+    private void findEpubsInFolder( File folder, List<File> items) {
+
+        if ( folder == null  || ! folder.exists() ) {
+            return;
+        }
 
         //If we got a single file, just import that.
         if ( ! folder.isDirectory() ) {
@@ -179,7 +179,7 @@ public class ImportTask extends QueueableAsyncTask<File, Integer, Void> implemen
             }
         }
 
-	}
+    }
 
     private void processFile( File file, List<File> items ) {
 
@@ -198,16 +198,16 @@ public class ImportTask extends QueueableAsyncTask<File, Integer, Void> implemen
             };
 
             config.getLibraryFolder().forEach( libraryFolder -> {
-                if ( fileName.startsWith(libraryFolder.getAbsolutePath() ) ) {
-                    add.execute( file );
-                }
-            });
+                    if ( fileName.startsWith(libraryFolder.getAbsolutePath() ) ) {
+                        add.execute( file );
+                    }
+                });
 
             config.getDownloadsFolder().forEach( downloadsFolder ->  {
-                if ( fileName.startsWith( downloadsFolder.getAbsolutePath() )) {
-                    add.execute( file );
-                }
-            });
+                    if ( fileName.startsWith( downloadsFolder.getAbsolutePath() )) {
+                        add.execute( file );
+                    }
+                });
         }
 
     }
@@ -223,7 +223,7 @@ public class ImportTask extends QueueableAsyncTask<File, Integer, Void> implemen
                 EpubReader epubReader = new EpubReader();
 
                 Book importedBook = epubReader.readEpubLazy(fileName, "UTF-8",
-                        Arrays.asList(MediatypeService.mediatypes));
+                    Arrays.asList(MediatypeService.mediatypes));
 
                 libraryService.storeBook(fileName, importedBook, false, this.copyToLibrary);
 
@@ -246,16 +246,16 @@ public class ImportTask extends QueueableAsyncTask<File, Integer, Void> implemen
     @Override
     public void doOnProgressUpdate(Integer... values) {
 
-		String message;
-		
-		if ( values[0] == UPDATE_IMPORT ) {
-			message = String.format(context.getString(R.string.importing), values[1], values[2]);		
-		} else {
-			message = String.format(context.getString(R.string.scan_folders), values[1]);			
-		}
-		
-		callBack.importStatusUpdate(message, silent);
-	}
+        String message;
+
+        if ( values[0] == UPDATE_IMPORT ) {
+            message = String.format(context.getString(R.string.importing), values[1], values[2]);
+        } else {
+            message = String.format(context.getString(R.string.scan_folders), values[1]);
+        }
+
+        callBack.importStatusUpdate(message, silent);
+    }
 
     @Override
     public void doOnCancelled(Option<Void> none) {
@@ -267,10 +267,10 @@ public class ImportTask extends QueueableAsyncTask<File, Integer, Void> implemen
 
         LOG.debug("Import task completed, imported " + booksImported  + " books.");
 
-		if ( importFailed != null ) {
-			callBack.importFailed(importFailed, silent);
-		} else {
-			this.callBack.importComplete(booksImported, errors, emptyLibrary, silent);
-		}
-	}
+        if ( importFailed != null ) {
+            callBack.importFailed(importFailed, silent);
+        } else {
+            this.callBack.importComplete(booksImported, errors, emptyLibrary, silent);
+        }
+    }
 }

--- a/src/net/nightwhistler/pageturner/library/KeyedQueryResult.java
+++ b/src/net/nightwhistler/pageturner/library/KeyedQueryResult.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -37,68 +37,68 @@ import static jedi.option.Options.some;
 /**
  * Special QueryResult which buffers the keys,
  * allowing for direct access.
- * 
+ *
  * @author Alex Kuiper
  *
  * @param <T>
  */
 public abstract class KeyedQueryResult<T> extends QueryResult<T> {
 
-	private List<String> keys;
-	private List<Character> alphabet;
+    private List<String> keys;
+    private List<Character> alphabet;
 
-	public KeyedQueryResult(Cursor cursor, List<String> keys ) {
-		super(cursor);		
-		this.keys = keys;	
-		
-		this.alphabet = calculateAlphaBet();
-	}
-	
-	public List<String> getKeys() {
-		return keys;
-	}
-	
-	private List<Character> calculateAlphaBet() {
+    public KeyedQueryResult(Cursor cursor, List<String> keys ) {
+        super(cursor);
+        this.keys = keys;
+
+        this.alphabet = calculateAlphaBet();
+    }
+
+    public List<String> getKeys() {
+        return keys;
+    }
+
+    private List<Character> calculateAlphaBet() {
 
         SortedSet<Character> firstLetters = new TreeSet<>(
-                collect(
-						select(keys, k -> k.length() > 0),
-						key -> key.charAt(0)
-				)
-		);
+            collect(
+                select(keys, k -> k.length() > 0),
+                key -> key.charAt(0)
+                    )
+                                                          );
 
         return unmodifiableList( new ArrayList<>(firstLetters) );
-	}
-	
-	public List<Character> getAlphabet() {
-		return this.alphabet;
-	}
-	
-	public Option<Character> getCharacterFor( int position ) {
-		String key = keys.get(position);
-		
-		if ( key.length() > 0 ) {
-			return some(toUpperCase(key.charAt(0)));
-		} else {
-			return none();
-		}
-	}
-	
-	public Option<Integer> getOffsetFor( Character c ) {
-		
-		Character input = toUpperCase(c);
-		
-		for ( int i=0; i < keys.size(); i++ ) {
-			String key = keys.get(i);
-			if ( key.length() > 0 ) {
-				Character keyStart = toUpperCase(key.charAt(0));
-				if ( keyStart.compareTo(input) >= 0 ) {
-					return some(i);
-				}
-			}			
-		}
-		
-		return none();
-	}
+    }
+
+    public List<Character> getAlphabet() {
+        return this.alphabet;
+    }
+
+    public Option<Character> getCharacterFor( int position ) {
+        String key = keys.get(position);
+
+        if ( key.length() > 0 ) {
+            return some(toUpperCase(key.charAt(0)));
+        } else {
+            return none();
+        }
+    }
+
+    public Option<Integer> getOffsetFor( Character c ) {
+
+        Character input = toUpperCase(c);
+
+        for ( int i=0; i < keys.size(); i++ ) {
+            String key = keys.get(i);
+            if ( key.length() > 0 ) {
+                Character keyStart = toUpperCase(key.charAt(0));
+                if ( keyStart.compareTo(input) >= 0 ) {
+                    return some(i);
+                }
+            }
+        }
+
+        return none();
+    }
 
 }

--- a/src/net/nightwhistler/pageturner/library/KeyedResultAdapter.java
+++ b/src/net/nightwhistler/pageturner/library/KeyedResultAdapter.java
@@ -29,90 +29,90 @@ import static jedi.option.Options.option;
 
 /**
  * Abstract adapter super-class for KeyedQueryResults
- * 
+ *
  * @author Alex Kuiper
  *
  */
 public abstract class KeyedResultAdapter extends QueryResultAdapter<LibraryBook> implements SectionIndexer {
-	
-	private KeyedQueryResult<LibraryBook> keyedResult;
-	
-	@Override
-	public void setResult(QueryResult<LibraryBook> result) {
-		
-		if ( result instanceof KeyedQueryResult) {
-			this.keyedResult = (KeyedQueryResult<LibraryBook>) result;	
-		} else {
-			this.keyedResult = null;
-		}
-		
-		super.setResult(result);
-	}		
-	
-	public boolean isKeyed() {
-		return this.keyedResult != null;
-	}
-	
-	public Option<String> getKey(int position) {
-		List<String> keys = keyedResult.getKeys();
-		
-		if ( keys == null || position >= keys.size() ) {
-			return none();
-		}
-		
-		return option(keys.get(position));
-	}
-	
-	public List<Character> getAlphabet() {
-		return keyedResult.getAlphabet();
-	}
 
-	@Override
-	public int getPositionForSection(int section) {
-		
-		if ( section < 0 || keyedResult == null ) {
-			return -1;
-		}
-		
-		List<Character> alphabet = this.keyedResult.getAlphabet();
-		
-		if ( section >= alphabet.size() ) {
-			return 0;
-		}
-		
-		Character c = alphabet.get(section);
+    private KeyedQueryResult<LibraryBook> keyedResult;
 
-		return this.keyedResult.getOffsetFor(c).getOrElse( -1 );
-	}
+    @Override
+    public void setResult(QueryResult<LibraryBook> result) {
 
-	@Override
-	public int getSectionForPosition(int position) {			
-		if ( this.keyedResult == null ) {
-			return 0;
-		}
-		
-		if ( position < 0 || position >= this.keyedResult.getSize() ) {
-			return 0;
-		}
-		
-		Option<Character> characterFor = this.keyedResult.getCharacterFor(position);
+        if ( result instanceof KeyedQueryResult) {
+            this.keyedResult = (KeyedQueryResult<LibraryBook>) result;
+        } else {
+            this.keyedResult = null;
+        }
+
+        super.setResult(result);
+    }
+
+    public boolean isKeyed() {
+        return this.keyedResult != null;
+    }
+
+    public Option<String> getKey(int position) {
+        List<String> keys = keyedResult.getKeys();
+
+        if ( keys == null || position >= keys.size() ) {
+            return none();
+        }
+
+        return option(keys.get(position));
+    }
+
+    public List<Character> getAlphabet() {
+        return keyedResult.getAlphabet();
+    }
+
+    @Override
+    public int getPositionForSection(int section) {
+
+        if ( section < 0 || keyedResult == null ) {
+            return -1;
+        }
+
+        List<Character> alphabet = this.keyedResult.getAlphabet();
+
+        if ( section >= alphabet.size() ) {
+            return 0;
+        }
+
+        Character c = alphabet.get(section);
+
+        return this.keyedResult.getOffsetFor(c).getOrElse( -1 );
+    }
+
+    @Override
+    public int getSectionForPosition(int position) {
+        if ( this.keyedResult == null ) {
+            return 0;
+        }
+
+        if ( position < 0 || position >= this.keyedResult.getSize() ) {
+            return 0;
+        }
+
+        Option<Character> characterFor = this.keyedResult.getCharacterFor(position);
 
         return characterFor.match(
-                c -> this.keyedResult.getAlphabet().indexOf(c),
-                () -> 0
-		);
-	}
+            c -> this.keyedResult.getAlphabet().indexOf(c),
+            () -> 0
+                                  );
+    }
 
-	@Override
-	public Object[] getSections() {			
-		
-		if ( keyedResult == null ) {
-			return new Object[0];
-		}
-		
-		List<Character> sectionNames = this.keyedResult.getAlphabet();
-		
-		return sectionNames.toArray( new Character[ sectionNames.size() ] );
-		
-	}
+    @Override
+    public Object[] getSections() {
+
+        if ( keyedResult == null ) {
+            return new Object[0];
+        }
+
+        List<Character> sectionNames = this.keyedResult.getAlphabet();
+
+        return sectionNames.toArray( new Character[ sectionNames.size() ] );
+
+    }
 }

--- a/src/net/nightwhistler/pageturner/library/LibraryBook.java
+++ b/src/net/nightwhistler/pageturner/library/LibraryBook.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -23,88 +23,88 @@ import java.util.Date;
 
 public class LibraryBook implements Serializable {
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = -4417866928191974513L;
+    /**
+     *
+     */
+    private static final long serialVersionUID = -4417866928191974513L;
 
-	private String fileName;
-	
-	private String title;
-	
-	private Author author;
-	
-	private byte[] coverImage;
-		
-	private Date lastRead;
-	
-	private Date addedToLibrary;
-	
-	private String description;
-	
-	private int progress;
-	
-	public String getDescription() {
-		return description;
-	}
-	
-	public void setDescription(String description) {
-		this.description = description;
-	}
+    private String fileName;
 
-	public String getTitle() {
-		return title;
-	}
+    private String title;
 
-	public void setTitle(String title) {
-		this.title = title;
-	}
+    private Author author;
 
-	public Author getAuthor() {
-		return author;
-	}
+    private byte[] coverImage;
 
-	public void setAuthor(Author author) {
-		this.author = author;
-	}
+    private Date lastRead;
 
-	public byte[] getCoverImage() {
-		return coverImage;
-	}
+    private Date addedToLibrary;
 
-	public void setCoverImage(byte[] coverImage) {
-		this.coverImage = coverImage;
-	}	
+    private String description;
 
-	public Date getLastRead() {
-		return lastRead;
-	}
+    private int progress;
 
-	public void setLastRead(Date lastRead) {
-		this.lastRead = lastRead;
-	}
-	
-	public void setFileName(String fileName) {
-		this.fileName = fileName;
-	}
-	
-	public String getFileName() {
-		return fileName;
-	}
-	
-	public Date getAddedToLibrary() {
-		return addedToLibrary;
-	}
-	
-	public void setAddedToLibrary(Date addedToLibrary) {
-		this.addedToLibrary = addedToLibrary;
-	}
-	
-	public void setProgress(int progress) {
-		this.progress = progress;
-	}
-	
-	public int getProgress() {
-		return progress;
-	}
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Author getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(Author author) {
+        this.author = author;
+    }
+
+    public byte[] getCoverImage() {
+        return coverImage;
+    }
+
+    public void setCoverImage(byte[] coverImage) {
+        this.coverImage = coverImage;
+    }
+
+    public Date getLastRead() {
+        return lastRead;
+    }
+
+    public void setLastRead(Date lastRead) {
+        this.lastRead = lastRead;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public Date getAddedToLibrary() {
+        return addedToLibrary;
+    }
+
+    public void setAddedToLibrary(Date addedToLibrary) {
+        this.addedToLibrary = addedToLibrary;
+    }
+
+    public void setProgress(int progress) {
+        this.progress = progress;
+    }
+
+    public int getProgress() {
+        return progress;
+    }
 }

--- a/src/net/nightwhistler/pageturner/library/LibraryDatabaseHelper.java
+++ b/src/net/nightwhistler/pageturner/library/LibraryDatabaseHelper.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -34,123 +34,123 @@ import java.util.List;
 public class LibraryDatabaseHelper extends SQLiteOpenHelper {
 
     private static final String LIB_BOOKS_TABLE = "lib_books";
-	
-	public enum Field { 
-		file_name("text primary key"), title("text"), a_first_name("text"),
-		a_last_name("text"), date_added("integer"), date_last_read("integer"), 
-		description("text"), cover_image("blob"), progress("integer");
-		
-		private String fieldDef;
-	
-		private Field(String fieldDef) { this.fieldDef = fieldDef; }		
-	}
 
-	public enum Order { ASC , DESC }
-	
-	private static final String DB_NAME = "PageTurnerLibrary";
-	private static final int VERSION = 4;
+    public enum Field {
+        file_name("text primary key"), title("text"), a_first_name("text"),
+        a_last_name("text"), date_added("integer"), date_last_read("integer"),
+        description("text"), cover_image("blob"), progress("integer");
 
-	private static String getCreateTableString() {
-		String create = "create table " + LIB_BOOKS_TABLE + " ( ";
-		
-		boolean first = true;
-		
-		for ( Field f: Field.values() ) {
-			
-			if ( first ) {
-				first = false;
-			} else {
-				create += ",";
-			}
-			
-			create += (" " + f.name() + " " + f.fieldDef);
-		}
-		
-		create += " );";
-		
-		return create;
-	}
-	
-	@Inject
-	public LibraryDatabaseHelper(Context context) {
-		super(context, DB_NAME, null, VERSION);		
-	}
-	
-	private synchronized SQLiteDatabase getDataBase() {
-		return getWritableDatabase();
-	}
-	
-	@Override
-	public void onCreate(SQLiteDatabase db) {
-		db.execSQL(getCreateTableString());		
-	}
-	
-	@Override
-	public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {		
-		
-		if ( oldVersion == 3 ) {
-			db.execSQL("ALTER TABLE " + LIB_BOOKS_TABLE + " ADD COLUMN progress integer" );
-		}
-	}	
-	
-	public void delete( String fileName ) {
-		
-		String[] args = { fileName };
-		
-		getDataBase().delete(LIB_BOOKS_TABLE, Field.file_name + " = ?", args );
-	}
+        private String fieldDef;
 
-	public void updateLastRead( String fileName, int progress ) {
-		
-		String whereClause = Field.file_name.toString() + " like ?";
-		String[] args = { "%" + fileName };
-		
-		ContentValues content = new ContentValues();
-		content.put( Field.date_last_read.toString(), new Date().getTime() );
-		
-		if ( progress != -1 ) {
-			content.put(Field.progress.toString(), progress );
-		}
-		
-		getDataBase().update(LIB_BOOKS_TABLE, content, whereClause, args);
-	}	
-	
-	public void storeNewBook(String fileName, String authorFirstName,
-			String authorLastName, String title, String description,
-			byte[] coverImage, boolean setLastRead) {		
-				
-		ContentValues content = new ContentValues();
-				
-		content.put(Field.title.toString(), title );
-		content.put(Field.a_first_name.toString(), authorFirstName );
-		content.put(Field.a_last_name.toString(), authorLastName );
-		content.put(Field.cover_image.toString(), coverImage );
-		content.put(Field.description.toString(), description );
-				
-		if ( setLastRead ) {
-			content.put(Field.date_last_read.toString(), new Date().getTime() );
-		}		
-			
-		content.put(Field.file_name.toString(), fileName );
-		content.put(Field.date_added.toString(), new Date().getTime() );			
-			
-		getDataBase().insert(LIB_BOOKS_TABLE, null, content);
-	}
-	
-	public boolean hasBook( String fileName ) {
-		Field[] fields = { Field.file_name };
-		String[] args = { "%" + fileName };
-		
-		String whereClause = Field.file_name.toString() + " like ?";
-		
-		Cursor findBook = getDataBase().query( LIB_BOOKS_TABLE, fieldsAsString(fields), whereClause,
-				args, null, null, null );
-		
-		boolean result =  findBook.getCount() != 0;
-		findBook.close();
-		
-		return result;
-	}
+        private Field(String fieldDef) { this.fieldDef = fieldDef; }
+    }
+
+    public enum Order { ASC , DESC }
+
+    private static final String DB_NAME = "PageTurnerLibrary";
+    private static final int VERSION = 4;
+
+    private static String getCreateTableString() {
+        String create = "create table " + LIB_BOOKS_TABLE + " ( ";
+
+        boolean first = true;
+
+        for ( Field f: Field.values() ) {
+
+            if ( first ) {
+                first = false;
+            } else {
+                create += ",";
+            }
+
+            create += (" " + f.name() + " " + f.fieldDef);
+        }
+
+        create += " );";
+
+        return create;
+    }
+
+    @Inject
+    public LibraryDatabaseHelper(Context context) {
+        super(context, DB_NAME, null, VERSION);
+    }
+
+    private synchronized SQLiteDatabase getDataBase() {
+        return getWritableDatabase();
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        db.execSQL(getCreateTableString());
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+
+        if ( oldVersion == 3 ) {
+            db.execSQL("ALTER TABLE " + LIB_BOOKS_TABLE + " ADD COLUMN progress integer" );
+        }
+    }
+
+    public void delete( String fileName ) {
+
+        String[] args = { fileName };
+
+        getDataBase().delete(LIB_BOOKS_TABLE, Field.file_name + " = ?", args );
+    }
+
+    public void updateLastRead( String fileName, int progress ) {
+
+        String whereClause = Field.file_name.toString() + " like ?";
+        String[] args = { "%" + fileName };
+
+        ContentValues content = new ContentValues();
+        content.put( Field.date_last_read.toString(), new Date().getTime() );
+
+        if ( progress != -1 ) {
+            content.put(Field.progress.toString(), progress );
+        }
+
+        getDataBase().update(LIB_BOOKS_TABLE, content, whereClause, args);
+    }
+
+    public void storeNewBook(String fileName, String authorFirstName,
+        String authorLastName, String title, String description,
+        byte[] coverImage, boolean setLastRead) {
+
+        ContentValues content = new ContentValues();
+
+        content.put(Field.title.toString(), title );
+        content.put(Field.a_first_name.toString(), authorFirstName );
+        content.put(Field.a_last_name.toString(), authorLastName );
+        content.put(Field.cover_image.toString(), coverImage );
+        content.put(Field.description.toString(), description );
+
+        if ( setLastRead ) {
+            content.put(Field.date_last_read.toString(), new Date().getTime() );
+        }
+
+        content.put(Field.file_name.toString(), fileName );
+        content.put(Field.date_added.toString(), new Date().getTime() );
+
+        getDataBase().insert(LIB_BOOKS_TABLE, null, content);
+    }
+
+    public boolean hasBook( String fileName ) {
+        Field[] fields = { Field.file_name };
+        String[] args = { "%" + fileName };
+
+        String whereClause = Field.file_name.toString() + " like ?";
+
+        Cursor findBook = getDataBase().query( LIB_BOOKS_TABLE, fieldsAsString(fields), whereClause,
+            args, null, null, null );
+
+        boolean result =  findBook.getCount() != 0;
+        findBook.close();
+
+        return result;
+    }
 
     private static String getFilterClause(String filter, String existingClause ) {
 
@@ -159,8 +159,8 @@ public class LibraryDatabaseHelper extends SQLiteOpenHelper {
         }
 
         String whereClause = "(" + Field.a_first_name + " like ? "
-                + " or " + Field.a_last_name + " like ? "
-                + " or " + Field.title + " like ? )";
+            + " or " + Field.a_last_name + " like ? "
+            + " or " + Field.title + " like ? )";
 
         if ( existingClause != null ) {
             whereClause = whereClause + " and " + existingClause;
@@ -173,7 +173,7 @@ public class LibraryDatabaseHelper extends SQLiteOpenHelper {
         if ( filter == null || filter.length() == 0 ) {
             return existingArgs;
         }
-        
+
         String searchString =  "%" + filter + "%";
 
         String[] newArgs;
@@ -194,77 +194,36 @@ public class LibraryDatabaseHelper extends SQLiteOpenHelper {
 
         return newArgs;
     }
-	
-	public synchronized  KeyedQueryResult<LibraryBook> findByField( Field fieldName, String fieldValue,
-			Field orderField, Order ordering, String filter) {
+
+    public synchronized  KeyedQueryResult<LibraryBook> findByField( Field fieldName, String fieldValue,
+        Field orderField, Order ordering, String filter) {
 
         String[] args = { fieldValue };
-		String whereClause;
-		
-		if ( fieldValue == null ) {
-			whereClause = fieldName.toString() + " is null";
-			args = null;
-		} else {
-			whereClause = fieldName.toString() + " = ?";			
-		}
+        String whereClause;
+
+        if ( fieldValue == null ) {
+            whereClause = fieldName.toString() + " is null";
+            args = null;
+        } else {
+            whereClause = fieldName.toString() + " = ?";
+        }
 
         if ( filter != null ) {
             whereClause = getFilterClause(filter, whereClause);
             args = getFilterArgs(args, filter);
         }
-		
-		Cursor cursor = getDataBase().query(LIB_BOOKS_TABLE,
-                fieldsAsString(Field.values()),
-				whereClause, args, null, null,
-				"LOWER(" + orderField + ") " + ordering  );		
-		
-		List<String> keys = getKeys(orderField, ordering);
-		
-		return new KeyedBookResult( cursor, keys );
-	}
 
-	public synchronized QueryResult<LibraryBook> findAllOrderedBy( Field fieldName, Order order, String filter ) {
+        Cursor cursor = getDataBase().query(LIB_BOOKS_TABLE,
+            fieldsAsString(Field.values()),
+            whereClause, args, null, null,
+            "LOWER(" + orderField + ") " + ordering  );
 
-        String whereClause = fieldName != null ? fieldName.toString() + " is not null" : null;
-        String[] args = new String[0];
+        List<String> keys = getKeys(orderField, ordering);
 
-        if ( filter != null ) {
-            whereClause = getFilterClause(filter, whereClause);
-            args = getFilterArgs(args, filter);
-        }
-						
-		Cursor cursor = getDataBase().query(LIB_BOOKS_TABLE,
-                fieldsAsString(Field.values()),
-				whereClause,args, null, null,
-				fieldName != null ? "LOWER(" + fieldName.toString() + ") " + order.toString() : null );		
-		
-		return new LibraryBookResult(cursor);
-	}	
-	
-	private List<String> getKeys( Field fieldName, Order order ) {
-		String[] keyField = { fieldName.toString() };
-		Cursor fieldCursor = getDataBase().query(LIB_BOOKS_TABLE,
-                keyField, null,	new String[0], null, null,
-				fieldName != null ? "LOWER(" + fieldName.toString() + ") " + order.toString() : null);
-				
-		List<String> keys = new ArrayList<String>();
-		fieldCursor.moveToFirst();
-		
-		fieldCursor.moveToFirst();
-		
-		while( !fieldCursor.isAfterLast()) {
-		     keys.add(fieldCursor.getString(0));
-		     fieldCursor.moveToNext();
-		}
-		
-		fieldCursor.close();
-		
-		return keys;
-	}
-	
-	public synchronized KeyedQueryResult<LibraryBook> findAllKeyedBy(Field fieldName, Order order, String filter ) {
-		
-		List<String> keys = getKeys(fieldName, order);
+        return new KeyedBookResult( cursor, keys );
+    }
+
+    public synchronized QueryResult<LibraryBook> findAllOrderedBy( Field fieldName, Order order, String filter ) {
 
         String whereClause = fieldName != null ? fieldName.toString() + " is not null" : null;
         String[] args = new String[0];
@@ -274,79 +233,120 @@ public class LibraryDatabaseHelper extends SQLiteOpenHelper {
             args = getFilterArgs(args, filter);
         }
 
+        Cursor cursor = getDataBase().query(LIB_BOOKS_TABLE,
+            fieldsAsString(Field.values()),
+            whereClause,args, null, null,
+            fieldName != null ? "LOWER(" + fieldName.toString() + ") " + order.toString() : null );
 
-		Cursor cursor = getDataBase().query(LIB_BOOKS_TABLE,
-                fieldsAsString(Field.values()),
-			    whereClause, args, null, null,
-				fieldName != null ? "LOWER(" + fieldName.toString() + ") " 
-						+ order.toString() : null );		
-		
-		return new KeyedBookResult(cursor, keys);
-	}	
-	
-	private class KeyedBookResult extends KeyedQueryResult<LibraryBook> {
-		
-		public KeyedBookResult(Cursor cursor, List<String> keys) {
-			super(cursor, keys);
-		}
-		
-		@Override
-		public LibraryBook convertRow(Cursor cursor) {
-			return doConvertRow(cursor);
-		}
-	}
-	
-	private class LibraryBookResult extends QueryResult<LibraryBook> {
-		
-		public LibraryBookResult(Cursor cursor) {
-			super(cursor);
-		}
-		
-		@Override
-		public LibraryBook convertRow(Cursor cursor) {
-			return doConvertRow(cursor);
-		}
-	}
-	
-	private static LibraryBook doConvertRow(Cursor cursor) {
-		
-		LibraryBook newBook = new LibraryBook();
-		
-		newBook.setAuthor(new Author( 
-				cursor.getString(Field.a_first_name.ordinal()), 
-				cursor.getString(Field.a_last_name.ordinal())));
-		
-		newBook.setTitle( cursor.getString(Field.title.ordinal()));
-		
-		newBook.setDescription(cursor.getString(Field.description.ordinal()));
-		
-		try {
-			newBook.setAddedToLibrary(new Date(cursor.getLong(Field.date_added.ordinal())));
-		} catch (RuntimeException r){}
-		
-		try {
-			newBook.setLastRead(new Date(cursor.getLong(Field.date_last_read.ordinal())));
-		} catch (RuntimeException r){}
-		
-		byte[] coverData = cursor.getBlob(Field.cover_image.ordinal());
-		newBook.setCoverImage(coverData);			
-		
-		newBook.setFileName( cursor.getString(Field.file_name.ordinal()));
-		
-		newBook.setProgress(cursor.getInt(Field.progress.ordinal()));
-		
-		return newBook;
-	}
+        return new LibraryBookResult(cursor);
+    }
 
-	
-	private static String[] fieldsAsString(Field[] values) {		
-		
-		String[] fieldsAsString = new String[values.length];
-		for ( int i=0; i < values.length; i++ ) {
-			fieldsAsString[i] = values[i].toString();
-		}
-		
-		return fieldsAsString;
-	}
-	
+    private List<String> getKeys( Field fieldName, Order order ) {
+        String[] keyField = { fieldName.toString() };
+        Cursor fieldCursor = getDataBase().query(LIB_BOOKS_TABLE,
+            keyField, null,        new String[0], null, null,
+            fieldName != null ? "LOWER(" + fieldName.toString() + ") " + order.toString() : null);
+
+        List<String> keys = new ArrayList<String>();
+        fieldCursor.moveToFirst();
+
+        fieldCursor.moveToFirst();
+
+        while( !fieldCursor.isAfterLast()) {
+            keys.add(fieldCursor.getString(0));
+            fieldCursor.moveToNext();
+        }
+
+        fieldCursor.close();
+
+        return keys;
+    }
+
+    public synchronized KeyedQueryResult<LibraryBook> findAllKeyedBy(Field fieldName, Order order, String filter ) {
+
+        List<String> keys = getKeys(fieldName, order);
+
+        String whereClause = fieldName != null ? fieldName.toString() + " is not null" : null;
+        String[] args = new String[0];
+
+        if ( filter != null ) {
+            whereClause = getFilterClause(filter, whereClause);
+            args = getFilterArgs(args, filter);
+        }
+
+
+        Cursor cursor = getDataBase().query(LIB_BOOKS_TABLE,
+            fieldsAsString(Field.values()),
+            whereClause, args, null, null,
+            fieldName != null ? "LOWER(" + fieldName.toString() + ") "
+            + order.toString() : null );
+
+        return new KeyedBookResult(cursor, keys);
+    }
+
+    private class KeyedBookResult extends KeyedQueryResult<LibraryBook> {
+
+        public KeyedBookResult(Cursor cursor, List<String> keys) {
+            super(cursor, keys);
+        }
+
+        @Override
+        public LibraryBook convertRow(Cursor cursor) {
+            return doConvertRow(cursor);
+        }
+    }
+
+    private class LibraryBookResult extends QueryResult<LibraryBook> {
+
+        public LibraryBookResult(Cursor cursor) {
+            super(cursor);
+        }
+
+        @Override
+        public LibraryBook convertRow(Cursor cursor) {
+            return doConvertRow(cursor);
+        }
+    }
+
+    private static LibraryBook doConvertRow(Cursor cursor) {
+
+        LibraryBook newBook = new LibraryBook();
+
+        newBook.setAuthor(new Author(
+                cursor.getString(Field.a_first_name.ordinal()),
+                cursor.getString(Field.a_last_name.ordinal())));
+
+        newBook.setTitle( cursor.getString(Field.title.ordinal()));
+
+        newBook.setDescription(cursor.getString(Field.description.ordinal()));
+
+        try {
+            newBook.setAddedToLibrary(new Date(cursor.getLong(Field.date_added.ordinal())));
+        } catch (RuntimeException r){}
+
+        try {
+            newBook.setLastRead(new Date(cursor.getLong(Field.date_last_read.ordinal())));
+        } catch (RuntimeException r){}
+
+        byte[] coverData = cursor.getBlob(Field.cover_image.ordinal());
+        newBook.setCoverImage(coverData);
+
+        newBook.setFileName( cursor.getString(Field.file_name.ordinal()));
+
+        newBook.setProgress(cursor.getInt(Field.progress.ordinal()));
+
+        return newBook;
+    }
+
+
+    private static String[] fieldsAsString(Field[] values) {
+
+        String[] fieldsAsString = new String[values.length];
+        for ( int i=0; i < values.length; i++ ) {
+            fieldsAsString[i] = values[i].toString();
+        }
+
+        return fieldsAsString;
+    }
+
 }

--- a/src/net/nightwhistler/pageturner/library/LibraryService.java
+++ b/src/net/nightwhistler/pageturner/library/LibraryService.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -25,36 +25,36 @@ import java.io.IOException;
 
 
 public interface LibraryService {
-	
-		
-	/**
-	 * Adds a new book to the library database, optionally copying it.
-	 * 
-	 * @param fileName
-	 * @param book
-	 * @param updateLastRead
-	 * @param copyFile
-	 * @throws IOException
-	 */
-	public void storeBook( String fileName, Book book, boolean updateLastRead, boolean copyFile ) throws IOException;
-	
-	public void updateReadingProgress( String fileName, int progress );
-	
-	public QueryResult<LibraryBook> findAllByLastRead(String filter);
-	
-	public QueryResult<LibraryBook> findAllByLastAdded(String filter);
-	
-	public QueryResult<LibraryBook> findAllByTitle(String filter);
-	
-	public QueryResult<LibraryBook> findAllByAuthor(String filter);
-	
-	public QueryResult<LibraryBook> findUnread(String filter);
-	
-	public Option<LibraryBook> getBook( String fileName );
-	
-	public boolean hasBook( String fileName );
-	
-	public void deleteBook( String fileName );
-	
-	public void close();
+
+
+    /**
+     * Adds a new book to the library database, optionally copying it.
+     *
+     * @param fileName
+     * @param book
+     * @param updateLastRead
+     * @param copyFile
+     * @throws IOException
+     */
+    public void storeBook( String fileName, Book book, boolean updateLastRead, boolean copyFile ) throws IOException;
+
+    public void updateReadingProgress( String fileName, int progress );
+
+    public QueryResult<LibraryBook> findAllByLastRead(String filter);
+
+    public QueryResult<LibraryBook> findAllByLastAdded(String filter);
+
+    public QueryResult<LibraryBook> findAllByTitle(String filter);
+
+    public QueryResult<LibraryBook> findAllByAuthor(String filter);
+
+    public QueryResult<LibraryBook> findUnread(String filter);
+
+    public Option<LibraryBook> getBook( String fileName );
+
+    public boolean hasBook( String fileName );
+
+    public void deleteBook( String fileName );
+
+    public void close();
 }

--- a/src/net/nightwhistler/pageturner/library/QueryResult.java
+++ b/src/net/nightwhistler/pageturner/library/QueryResult.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -23,52 +23,52 @@ import android.database.Cursor;
 /**
  * A QueryResult maps a Cursor and performs
  * basic O/R mapping.
- * 
+ *
  * Subclasses should implement the actual mapping
  * from a row to an object by overriding convertRow()
- * 
+ *
  * @author Alex Kuiper
  *
  * @param <T> the type to map to.
  */
 public abstract class QueryResult<T> {
 
-	private Cursor wrappedCursor;
-	
-	private int limit = -1;
-	
-	public QueryResult(Cursor cursor) {
-		this.wrappedCursor = cursor;
-		cursor.moveToFirst();
-	}
-	
-	public void setLimit(int limit) {
-		this.limit = limit;
-	}
-	
-	public int getSize() {
-		
-		int count = this.wrappedCursor.getCount(); 
-		
-		if ( limit != -1 && count > limit ) {
-			return limit;
-		}
-		
-		return count;
-	}
-	
-	public T getItemAt(int index) {		
-		this.wrappedCursor.moveToPosition(index);		
-		return convertRow(this.wrappedCursor);		
-	}
-	
-	public boolean hasNext() {
-		return ! this.wrappedCursor.isAfterLast();
-	}
-	
-	public void close() {
-		this.wrappedCursor.close();		
-	}
-	
-	public abstract T convertRow( Cursor cursor );
+    private Cursor wrappedCursor;
+
+    private int limit = -1;
+
+    public QueryResult(Cursor cursor) {
+        this.wrappedCursor = cursor;
+        cursor.moveToFirst();
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    public int getSize() {
+
+        int count = this.wrappedCursor.getCount();
+
+        if ( limit != -1 && count > limit ) {
+            return limit;
+        }
+
+        return count;
+    }
+
+    public T getItemAt(int index) {
+        this.wrappedCursor.moveToPosition(index);
+        return convertRow(this.wrappedCursor);
+    }
+
+    public boolean hasNext() {
+        return ! this.wrappedCursor.isAfterLast();
+    }
+
+    public void close() {
+        this.wrappedCursor.close();
+    }
+
+    public abstract T convertRow( Cursor cursor );
 }

--- a/src/net/nightwhistler/pageturner/library/QueryResultAdapter.java
+++ b/src/net/nightwhistler/pageturner/library/QueryResultAdapter.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -28,67 +28,67 @@ import static jedi.option.Options.option;
 
 /**
  * A ListAdapter which uses QueryResult objects.
- * 
+ *
  * @author Alex Kuiper
  *
  * @param <T> the type of objects in the result.
  */
 public abstract class QueryResultAdapter<T> extends BaseAdapter {
 
-	QueryResult<T> result;
-	
-	public void setResult(QueryResult<T> result) {
-		
-		if ( this.result != null ) {
-			this.result.close();
-		}
-		
-		this.result = result;
-		notifyDataSetChanged();
-	}
-	
-	public void clear() {
-		if ( this.result != null ) {
-			result.close();
-		}
-		
-		result = null;
-		notifyDataSetChanged();
-	}
-	
-	@Override
-	public int getCount() {
-		if ( this.result == null ) {
-			return 0;
-		}
-		
-		return result.getSize();
-	}
-	
-	@Override
-	public Object getItem(int position) {
-		return getResultAt(position).unsafeGet();
-	}
-	
-	@Override
-	public long getItemId(int position) {
-		return position;
-	}
-	
-	@Override
-	public View getView(int position, View convertView, ViewGroup parent) {
-		return getView(position, result.getItemAt(position), convertView, parent);
-	}
-	
-	public Option<T> getResultAt(int position) {
-		
-		if ( result == null ) {
-			return none();
-		}
-		
-		return option(result.getItemAt(position));
-	}
-	
-	public abstract View getView( int index, T object, View convertView, ViewGroup parent );
-	
+    QueryResult<T> result;
+
+    public void setResult(QueryResult<T> result) {
+
+        if ( this.result != null ) {
+            this.result.close();
+        }
+
+        this.result = result;
+        notifyDataSetChanged();
+    }
+
+    public void clear() {
+        if ( this.result != null ) {
+            result.close();
+        }
+
+        result = null;
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public int getCount() {
+        if ( this.result == null ) {
+            return 0;
+        }
+
+        return result.getSize();
+    }
+
+    @Override
+    public Object getItem(int position) {
+        return getResultAt(position).unsafeGet();
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        return getView(position, result.getItemAt(position), convertView, parent);
+    }
+
+    public Option<T> getResultAt(int position) {
+
+        if ( result == null ) {
+            return none();
+        }
+
+        return option(result.getItemAt(position));
+    }
+
+    public abstract View getView( int index, T object, View convertView, ViewGroup parent );
+
 }

--- a/src/net/nightwhistler/pageturner/prefs/ColourChooserPref.java
+++ b/src/net/nightwhistler/pageturner/prefs/ColourChooserPref.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -30,93 +30,93 @@ import yuku.ambilwarna.AmbilWarnaDialog.OnAmbilWarnaListener;
 
 public class ColourChooserPref extends DialogPreference implements OnAmbilWarnaListener {
 
-	private static final String androidns="http://schemas.android.com/apk/res/android";
-	
-	int defaultColour;	
-	
-	public ColourChooserPref(Context context, AttributeSet attributes) {
-		super(context, attributes);		
-		this.defaultColour = attributes.getAttributeIntValue(androidns,"defaultValue", Color.BLACK);		
-	}
-	
-	@Override
-	public void setDefaultValue(Object defaultValue) {		
-		super.setDefaultValue(defaultValue);
-		
-		this.defaultColour = (Integer) defaultValue;
-	}
-	
-	@Override
-	public void onCancel(AmbilWarnaDialog dialog) {
-		// TODO Auto-generated method stub
-		
-	}
-	
-	@Override
-	public void onOk(AmbilWarnaDialog dialog, int color) {
-		persistInt(color);		
-	}
-	
-	@Override
-	protected void onClick() {
-		getDialog().show();
-	}
-	
-	@Override
-	public Dialog getDialog() {		
-		
-		int colour = this.getPersistedInt( this.defaultColour );
-		
-		return new AmbilWarnaDialog(this.getContext(), colour, this ).getDialog();
-		
-	}
-	
-	public class Square extends Drawable
-	{
-	    private final Paint mPaint;
-	    private final RectF mRect;
+    private static final String androidns="http://schemas.android.com/apk/res/android";
 
-	    public Square()
-	    {
-	        mPaint = new Paint();
-	        mRect = new RectF();
-	    }
+    int defaultColour;
 
-	    @Override
-	    public void draw(Canvas canvas)
-	    {
-	        // Set the correct values in the Paint
-	        mPaint.setColor( getPersistedInt(defaultColour) );
-	    	
-	        mPaint.setStrokeWidth(2);
-	        mPaint.setStyle(Style.FILL);
+    public ColourChooserPref(Context context, AttributeSet attributes) {
+        super(context, attributes);
+        this.defaultColour = attributes.getAttributeIntValue(androidns,"defaultValue", Color.BLACK);
+    }
 
-	        // Adjust the rect
-	        mRect.left = 15.0f;
-	        mRect.top = 50.0f;
-	        mRect.right = 55.0f;
-	        mRect.bottom = 75.0f;
+    @Override
+    public void setDefaultValue(Object defaultValue) {
+        super.setDefaultValue(defaultValue);
 
-	        // Draw it
-	        canvas.drawRoundRect(mRect, 0.5f, 0.5f, mPaint);
-	    }
+        this.defaultColour = (Integer) defaultValue;
+    }
 
-	    @Override
-	    public int getOpacity()
-	    {
-	        return PixelFormat.OPAQUE;
-	    }
+    @Override
+    public void onCancel(AmbilWarnaDialog dialog) {
+        // TODO Auto-generated method stub
 
-	    @Override
-	    public void setAlpha(int arg0)
-	    {
-	    }
+    }
 
-	    @Override
-	    public void setColorFilter(ColorFilter arg0)
-	    {
-	    }
-	}
+    @Override
+    public void onOk(AmbilWarnaDialog dialog, int color) {
+        persistInt(color);
+    }
 
-	
+    @Override
+    protected void onClick() {
+        getDialog().show();
+    }
+
+    @Override
+    public Dialog getDialog() {
+
+        int colour = this.getPersistedInt( this.defaultColour );
+
+        return new AmbilWarnaDialog(this.getContext(), colour, this ).getDialog();
+
+    }
+
+    public class Square extends Drawable
+    {
+        private final Paint mPaint;
+        private final RectF mRect;
+
+        public Square()
+        {
+            mPaint = new Paint();
+            mRect = new RectF();
+        }
+
+        @Override
+        public void draw(Canvas canvas)
+        {
+            // Set the correct values in the Paint
+            mPaint.setColor( getPersistedInt(defaultColour) );
+
+            mPaint.setStrokeWidth(2);
+            mPaint.setStyle(Style.FILL);
+
+            // Adjust the rect
+            mRect.left = 15.0f;
+            mRect.top = 50.0f;
+            mRect.right = 55.0f;
+            mRect.bottom = 75.0f;
+
+            // Draw it
+            canvas.drawRoundRect(mRect, 0.5f, 0.5f, mPaint);
+        }
+
+        @Override
+        public int getOpacity()
+        {
+            return PixelFormat.OPAQUE;
+        }
+
+        @Override
+        public void setAlpha(int arg0)
+        {
+        }
+
+        @Override
+        public void setColorFilter(ColorFilter arg0)
+        {
+        }
+    }
+
+
 }

--- a/src/net/nightwhistler/pageturner/prefs/LanguageSwitchPreference.java
+++ b/src/net/nightwhistler/pageturner/prefs/LanguageSwitchPreference.java
@@ -26,25 +26,25 @@ import android.widget.Toast;
 import net.nightwhistler.pageturner.R;
 
 public class LanguageSwitchPreference extends ListPreference {
-	
-	private Context context;	
 
-	private String oldValue;
+    private Context context;
 
-	public LanguageSwitchPreference(Context context, AttributeSet attributes) {
-		super(context, attributes);
-		this.context = context;				
-	}
-	
-	@Override
-	public void setValue(String value) {
-		super.setValue(value);
-		
-		if (oldValue != null && !value.equalsIgnoreCase(oldValue) ) {
-			Toast.makeText(context, R.string.language_switch_message, Toast.LENGTH_LONG).show();			
-		}
-		
-		this.oldValue = value;
-	}
-	
+    private String oldValue;
+
+    public LanguageSwitchPreference(Context context, AttributeSet attributes) {
+        super(context, attributes);
+        this.context = context;
+    }
+
+    @Override
+    public void setValue(String value) {
+        super.setValue(value);
+
+        if (oldValue != null && !value.equalsIgnoreCase(oldValue) ) {
+            Toast.makeText(context, R.string.language_switch_message, Toast.LENGTH_LONG).show();
+        }
+
+        this.oldValue = value;
+    }
+
 }

--- a/src/net/nightwhistler/pageturner/scheduling/QueuedTask.java
+++ b/src/net/nightwhistler/pageturner/scheduling/QueuedTask.java
@@ -74,6 +74,3 @@ public class QueuedTask<A, B, C> {
         return task.toString();
     }
 }
-
-
-

--- a/src/net/nightwhistler/pageturner/scheduling/TaskQueue.java
+++ b/src/net/nightwhistler/pageturner/scheduling/TaskQueue.java
@@ -36,7 +36,7 @@ public class TaskQueue {
         this.taskQueue.add(new QueuedTask<>(task, parameters));
 
         Log.d("TaskQueue", "Scheduled task of type " + task
-                + " total tasks scheduled now: " + this.taskQueue.size() );
+            + " total tasks scheduled now: " + this.taskQueue.size() );
 
         if ( this.taskQueue.size() == 1 ) {
             Log.d("TaskQueue",  "Starting task " + taskQueue.peek() + " since task queue is 1.");
@@ -71,7 +71,7 @@ public class TaskQueue {
             taskQueue.add( 0, new QueuedTask<A, B, C>(task, parameters));
 
             Log.d("TaskQueue", "Starting task of type " + taskQueue.peek()
-                    + " with queue " + getQueueAsString() );
+                + " with queue " + getQueueAsString() );
 
             taskQueue.peek().execute();
         }
@@ -134,8 +134,8 @@ public class TaskQueue {
             if ( queuedTask.getTask() != task ) {
 
                 String errorMsg = "Tasks out of sync! Expected "+
-                        queuedTask.getTask() + " but got " + task +
-                        " with queue: " + getQueueAsString();
+                    queuedTask.getTask() + " but got " + task +
+                    " with queue: " + getQueueAsString();
                 Log.e("TaskQueue", errorMsg );
 
                 throw new RuntimeException(errorMsg);
@@ -148,7 +148,7 @@ public class TaskQueue {
         }
 
         Log.d("TaskQueue", "Total tasks scheduled now: " + this.taskQueue.size()
-                + " with queue: " + getQueueAsString() );
+            + " with queue: " + getQueueAsString() );
 
         if ( ! this.taskQueue.isEmpty() ) {
 

--- a/src/net/nightwhistler/pageturner/ssl/EasySSLSocketFactory.java
+++ b/src/net/nightwhistler/pageturner/ssl/EasySSLSocketFactory.java
@@ -67,7 +67,7 @@ public class EasySSLSocketFactory implements SocketFactory, LayeredSocketFactory
      *      java.net.InetAddress, int, org.apache.http.params.HttpParams)
      */
     public Socket connectSocket(Socket sock, String host, int port, InetAddress localAddress, int localPort,
-                                HttpParams params) throws IOException, UnknownHostException, ConnectTimeoutException {
+        HttpParams params) throws IOException, UnknownHostException, ConnectTimeoutException {
         int connTimeout = HttpConnectionParams.getConnectionTimeout(params);
         int soTimeout = HttpConnectionParams.getSoTimeout(params);
         InetSocketAddress remoteAddress = new InetSocketAddress(host, port);
@@ -107,7 +107,7 @@ public class EasySSLSocketFactory implements SocketFactory, LayeredSocketFactory
      *      boolean)
      */
     public Socket createSocket(Socket socket, String host, int port, boolean autoClose) throws IOException,
-            UnknownHostException {
+                                                                                               UnknownHostException {
         return getSSLContext().getSocketFactory().createSocket(socket, host, port, autoClose);
     }
 

--- a/src/net/nightwhistler/pageturner/sync/AccessException.java
+++ b/src/net/nightwhistler/pageturner/sync/AccessException.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -20,12 +20,12 @@ package net.nightwhistler.pageturner.sync;
 
 public class AccessException extends Exception {
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 4712242407202301724L;
+    /**
+     *
+     */
+    private static final long serialVersionUID = 4712242407202301724L;
 
-	public AccessException(String message) {
-		super(message);
-	}
+    public AccessException(String message) {
+        super(message);
+    }
 }

--- a/src/net/nightwhistler/pageturner/sync/BookProgress.java
+++ b/src/net/nightwhistler/pageturner/sync/BookProgress.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -22,49 +22,49 @@ import java.util.Date;
 
 public class BookProgress {
 
-	String fileName;
-	
-	int index;
-	
-	private int progress;
-	
-	private Date timeStamp;
-	private int percentage;
-	
-	private String deviceName;
-	
-	public BookProgress( String fileName, int index, int progress, int percentage,
-			Date timeStamp, String deviceName ) {
-		this.fileName = fileName;
-		this.index = index;
-		this.progress = progress;
-		this.percentage = percentage;
-		this.timeStamp = timeStamp;
-		this.deviceName = deviceName;
-	}
-	
-	public String getFileName() {
-		return fileName;
-	}
-	
-	public int getIndex() {
-		return index;
-	}
-	
-	public int getProgress() {
-		return progress;
-	}
-	
-	public String getDeviceName() {
-		return deviceName;
-	}
-	
-	public int getPercentage() {
-		return percentage;
-	}
-	
-	public Date getTimeStamp() {
-		return timeStamp;
-	}
-	
+    String fileName;
+
+    int index;
+
+    private int progress;
+
+    private Date timeStamp;
+    private int percentage;
+
+    private String deviceName;
+
+    public BookProgress( String fileName, int index, int progress, int percentage,
+        Date timeStamp, String deviceName ) {
+        this.fileName = fileName;
+        this.index = index;
+        this.progress = progress;
+        this.percentage = percentage;
+        this.timeStamp = timeStamp;
+        this.deviceName = deviceName;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public int getProgress() {
+        return progress;
+    }
+
+    public String getDeviceName() {
+        return deviceName;
+    }
+
+    public int getPercentage() {
+        return percentage;
+    }
+
+    public Date getTimeStamp() {
+        return timeStamp;
+    }
+
 }

--- a/src/net/nightwhistler/pageturner/sync/PageTurnerWebProgressService.java
+++ b/src/net/nightwhistler/pageturner/sync/PageTurnerWebProgressService.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -53,149 +53,149 @@ import static jedi.option.Options.some;
 
 @ContextSingleton
 public class PageTurnerWebProgressService implements ProgressService {
-	
-	private static final Logger LOG = LoggerFactory.getLogger(PageTurnerWebProgressService.class);	
-	
-	private Configuration config;
-	
-	private HttpClient client;
-	private HttpContext httpContext;
-	
-	private static final int HTTP_SUCCESS = 200;
-	private static final int HTTP_FORBIDDEN = 403;
-    private static final int HTTP_NOT_FOUND = 404;
-	
-	private SimpleDateFormat dateFormat;
 
-	@Inject
-	public PageTurnerWebProgressService(Context context, Configuration config, HttpClient client) {
-		this.httpContext = new BasicHttpContext();
-		this.config = config;
+    private static final Logger LOG = LoggerFactory.getLogger(PageTurnerWebProgressService.class);
+
+    private Configuration config;
+
+    private HttpClient client;
+    private HttpContext httpContext;
+
+    private static final int HTTP_SUCCESS = 200;
+    private static final int HTTP_FORBIDDEN = 403;
+    private static final int HTTP_NOT_FOUND = 404;
+
+    private SimpleDateFormat dateFormat;
+
+    @Inject
+    public PageTurnerWebProgressService(Context context, Configuration config, HttpClient client) {
+        this.httpContext = new BasicHttpContext();
+        this.config = config;
         this.client = client;
-		
-		this.dateFormat = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-		// explicitly set timezone of input if needed
-		dateFormat.setTimeZone(java.util.TimeZone.getTimeZone("Zulu"));
+
+        this.dateFormat = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        // explicitly set timezone of input if needed
+        dateFormat.setTimeZone(java.util.TimeZone.getTimeZone("Zulu"));
     }
 
-	@Override
-	public Option<List<BookProgress>> getProgress(String fileName) throws AccessException {
-		
-		String userId = this.config.getSynchronizationEmail();
-		String accessKey = this.config.getSynchronizationAccessKey();
-		
-		if ( "".equals( userId ) || "".equals(fileName) ) {
-			LOG.debug( "Empty username or filename. Aborting sync. (" + userId + " / " + fileName + ")" );
-			return none();
-		}
-		
-		String key = computeKey(fileName);
-		
-		LOG.debug( "Doing progress query for key: " + key );
-		
-		HttpGet get = new HttpGet( getSyncServerURL() + key + "?accessKey=" + URLEncoder.encode(accessKey) );
+    @Override
+    public Option<List<BookProgress>> getProgress(String fileName) throws AccessException {
+
+        String userId = this.config.getSynchronizationEmail();
+        String accessKey = this.config.getSynchronizationAccessKey();
+
+        if ( "".equals( userId ) || "".equals(fileName) ) {
+            LOG.debug( "Empty username or filename. Aborting sync. (" + userId + " / " + fileName + ")" );
+            return none();
+        }
+
+        String key = computeKey(fileName);
+
+        LOG.debug( "Doing progress query for key: " + key );
+
+        HttpGet get = new HttpGet( getSyncServerURL() + key + "?accessKey=" + URLEncoder.encode(accessKey) );
         get.setHeader("User-Agent", config.getUserAgent() );
-		
-		try {
-			HttpResponse response = client.execute(get);
-			
-			int statusCode = response.getStatusLine().getStatusCode();
-			LOG.debug( "Got status " + statusCode + " from server.");
-			
-			if ( statusCode == HTTP_FORBIDDEN ) {
-				throw new AccessException( EntityUtils.toString(response.getEntity()) );
-			}
+
+        try {
+            HttpResponse response = client.execute(get);
+
+            int statusCode = response.getStatusLine().getStatusCode();
+            LOG.debug( "Got status " + statusCode + " from server.");
+
+            if ( statusCode == HTTP_FORBIDDEN ) {
+                throw new AccessException( EntityUtils.toString(response.getEntity()) );
+            }
 
             if ( statusCode == HTTP_NOT_FOUND ) {
                 return some(new ArrayList<>());
             }
-			
-			if ( statusCode != HTTP_SUCCESS ) {
-				return none();
-			}
-			
-			String responseString = EntityUtils.toString(response.getEntity());
-			
-			JSONArray jsonArray = new JSONArray(responseString);
-			
-			List<BookProgress> result = new ArrayList<>();
-			
-			for ( int i=0; i < jsonArray.length(); i++ ) {
-				
-				JSONObject json = jsonArray.getJSONObject(i);
-				
-				int index = json.getInt("bookIndex");
-				int progress = json.getInt("progress");
-				int percentage = json.getInt("percentage");
-				
-				Date timeStamp = dateFormat.parse( json.getString("storedOn") );
-				
-				String deviceName = json.getString("deviceName");
-			
-				result.add( new BookProgress(fileName, index, progress, percentage, timeStamp, deviceName ) );
-			}
-			
-			return some(result);
-			
-		} catch (IOException e) {
-			LOG.error( "Got error while querying server", e );
-		} catch (JSONException json ) {
-			LOG.error( "Error reading response", json );
-		} catch (ParseException p ) {
-			LOG.error( "Invalid date", p );
-		} catch ( IllegalStateException s ) {
+
+            if ( statusCode != HTTP_SUCCESS ) {
+                return none();
+            }
+
+            String responseString = EntityUtils.toString(response.getEntity());
+
+            JSONArray jsonArray = new JSONArray(responseString);
+
+            List<BookProgress> result = new ArrayList<>();
+
+            for ( int i=0; i < jsonArray.length(); i++ ) {
+
+                JSONObject json = jsonArray.getJSONObject(i);
+
+                int index = json.getInt("bookIndex");
+                int progress = json.getInt("progress");
+                int percentage = json.getInt("percentage");
+
+                Date timeStamp = dateFormat.parse( json.getString("storedOn") );
+
+                String deviceName = json.getString("deviceName");
+
+                result.add( new BookProgress(fileName, index, progress, percentage, timeStamp, deviceName ) );
+            }
+
+            return some(result);
+
+        } catch (IOException e) {
+            LOG.error( "Got error while querying server", e );
+        } catch (JSONException json ) {
+            LOG.error( "Error reading response", json );
+        } catch (ParseException p ) {
+            LOG.error( "Invalid date", p );
+        } catch ( IllegalStateException s ) {
             LOG.error( "Tried query in illegal state", s );
         }
 
         return none();
-	}
-	
-	@Override
-	public void storeProgress(String fileName, int index, int progress, int percentage) {
-				
-		if ( ! config.isSyncEnabled() ) {
-			return;
-		}	
-		
-		String key = computeKey(fileName);
-				
-		HttpPost post = new HttpPost( getSyncServerURL() + key );
-		
-		String filePart = fileName;
-		
-		if ( fileName.indexOf("/") != -1 ) {
-			filePart = fileName.substring( fileName.lastIndexOf('/') );
-		}
-		
-		try {
-			
-			List<NameValuePair> pairs = new ArrayList<NameValuePair>();
-			pairs.add( new BasicNameValuePair("bookIndex", "" + index ) );
-			pairs.add(new BasicNameValuePair("progress", "" + progress ));
-			pairs.add(new BasicNameValuePair("title", Integer.toHexString( filePart.hashCode() )));
-			pairs.add(new BasicNameValuePair("deviceName", this.config.getDeviceName() ));
-			pairs.add(new BasicNameValuePair("percentage", "" + percentage ));
-			pairs.add(new BasicNameValuePair("userId", Integer.toHexString( this.config.getSynchronizationEmail().hashCode() )));
-			pairs.add(new BasicNameValuePair("accessKey", this.config.getSynchronizationAccessKey()));
-			
-			post.setEntity( new UrlEncodedFormEntity(pairs) );
+    }
+
+    @Override
+    public void storeProgress(String fileName, int index, int progress, int percentage) {
+
+        if ( ! config.isSyncEnabled() ) {
+            return;
+        }
+
+        String key = computeKey(fileName);
+
+        HttpPost post = new HttpPost( getSyncServerURL() + key );
+
+        String filePart = fileName;
+
+        if ( fileName.indexOf("/") != -1 ) {
+            filePart = fileName.substring( fileName.lastIndexOf('/') );
+        }
+
+        try {
+
+            List<NameValuePair> pairs = new ArrayList<NameValuePair>();
+            pairs.add( new BasicNameValuePair("bookIndex", "" + index ) );
+            pairs.add(new BasicNameValuePair("progress", "" + progress ));
+            pairs.add(new BasicNameValuePair("title", Integer.toHexString( filePart.hashCode() )));
+            pairs.add(new BasicNameValuePair("deviceName", this.config.getDeviceName() ));
+            pairs.add(new BasicNameValuePair("percentage", "" + percentage ));
+            pairs.add(new BasicNameValuePair("userId", Integer.toHexString( this.config.getSynchronizationEmail().hashCode() )));
+            pairs.add(new BasicNameValuePair("accessKey", this.config.getSynchronizationAccessKey()));
+
+            post.setEntity( new UrlEncodedFormEntity(pairs) );
             post.setHeader("User-Agent", config.getUserAgent() );
 
-			
-			HttpResponse response = client.execute(post, this.httpContext);
-			
-			if ( response.getStatusLine().getStatusCode() == HTTP_FORBIDDEN ) {
-				throw new AccessException( EntityUtils.toString(response.getEntity()) );
-			}
-			
-			LOG.debug("Got status " + response.getStatusLine().getStatusCode() + " from server.");
-			
-		} catch (Exception io) {	
-			LOG.error("Got error while POSTing update:", io);	
-			//fail silently
-		}	
-		
-	}
+
+            HttpResponse response = client.execute(post, this.httpContext);
+
+            if ( response.getStatusLine().getStatusCode() == HTTP_FORBIDDEN ) {
+                throw new AccessException( EntityUtils.toString(response.getEntity()) );
+            }
+
+            LOG.debug("Got status " + response.getStatusLine().getStatusCode() + " from server.");
+
+        } catch (Exception io) {
+            LOG.error("Got error while POSTing update:", io);
+            //fail silently
+        }
+
+    }
 
     private String getSyncServerURL() {
         String url = config.getSyncServerURL();
@@ -205,19 +205,19 @@ public class PageTurnerWebProgressService implements ProgressService {
 
         return url;
     }
-	
-	private String computeKey( String fileName ) {		
-		
-		String filePart = fileName;
-		
-		if ( fileName.indexOf("/") != -1 ) {
-			filePart = fileName.substring( fileName.lastIndexOf('/') );
-		}
-		
-		String plainTextKey = this.config.getSynchronizationEmail() + ":" + filePart;
-		
-		String hash = Integer.toHexString( plainTextKey.hashCode() );
-		
-		return hash;		
-	}
+
+    private String computeKey( String fileName ) {
+
+        String filePart = fileName;
+
+        if ( fileName.indexOf("/") != -1 ) {
+            filePart = fileName.substring( fileName.lastIndexOf('/') );
+        }
+
+        String plainTextKey = this.config.getSynchronizationEmail() + ":" + filePart;
+
+        String hash = Integer.toHexString( plainTextKey.hashCode() );
+
+        return hash;
+    }
 }

--- a/src/net/nightwhistler/pageturner/sync/ProgressService.java
+++ b/src/net/nightwhistler/pageturner/sync/ProgressService.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -24,20 +24,20 @@ import java.util.List;
 
 public interface ProgressService {
 
-	/**
-	 * Stores the progress for the given book.
-	 * @param userId
-	 * @param fileName
-	 * @param progress
-	 */
-	public void storeProgress( String fileName, int index, int progress, int percentage ) throws AccessException;
+    /**
+     * Stores the progress for the given book.
+     * @param userId
+     * @param fileName
+     * @param progress
+     */
+    public void storeProgress( String fileName, int index, int progress, int percentage ) throws AccessException;
 
-	/**
-	 * Returns the progress, or -1 of it wasn't found.
-	 *
-	 * @param fileName
-	 * @return
-	 */
-	public Option<List<BookProgress>> getProgress( String fileName ) throws AccessException;
+    /**
+     * Returns the progress, or -1 of it wasn't found.
+     *
+     * @param fileName
+     * @return
+     */
+    public Option<List<BookProgress>> getProgress( String fileName ) throws AccessException;
 
 }

--- a/src/net/nightwhistler/pageturner/tts/TTSPlaybackItem.java
+++ b/src/net/nightwhistler/pageturner/tts/TTSPlaybackItem.java
@@ -36,7 +36,7 @@ public class TTSPlaybackItem {
     private String fileName;
 
     public TTSPlaybackItem(CharSequence text, MediaPlayer mediaPlayer,
-                           int totalTextLength, int offset, boolean lastElementOfPage, String fileName) {
+        int totalTextLength, int offset, boolean lastElementOfPage, String fileName) {
         this.text = text;
         this.mediaPlayer = mediaPlayer;
         this.totalTextLength = totalTextLength;
@@ -47,8 +47,8 @@ public class TTSPlaybackItem {
 
     public void setOnSpeechCompletedCallback( final SpeechCompletedCallback callback ) {
         this.mediaPlayer.setOnCompletionListener(
-                mediaPlayer -> callback.speechCompleted(TTSPlaybackItem.this, mediaPlayer)
-        );
+            mediaPlayer -> callback.speechCompleted(TTSPlaybackItem.this, mediaPlayer)
+                                                 );
     }
 
     public int getOffset() {

--- a/src/net/nightwhistler/pageturner/tts/TTSPlaybackQueue.java
+++ b/src/net/nightwhistler/pageturner/tts/TTSPlaybackQueue.java
@@ -26,10 +26,10 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /*
-Playback queue which is thread-safe, so it can be a singleton.
+  Playback queue which is thread-safe, so it can be a singleton.
 
-It only accepts items when it has first been activated.
- */
+  It only accepts items when it has first been activated.
+*/
 public class TTSPlaybackQueue {
 
     private boolean active;

--- a/src/net/nightwhistler/pageturner/view/AlphabetBar.java
+++ b/src/net/nightwhistler/pageturner/view/AlphabetBar.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2012 Alex Kuiper
- * 
+ *
  * This file is part of PageTurner
  *
  * PageTurner is free software: you can redistribute it and/or modify
@@ -17,7 +17,7 @@
  * along with PageTurner.  If not, see <http://www.gnu.org/licenses/>.*
  *
  * Based on the AlphabetListView which can be found here:
- * 
+ *
  * http://devtcg.blogspot.com/2008/03/custom-android-list-view-widget-to.html
  */
 package net.nightwhistler.pageturner.view;
@@ -42,9 +42,9 @@ import java.util.List;
 public class AlphabetBar extends LinearLayout
 {
     private static final String TAG = "AlphabetBar";
-    
+
     private List<Character> alphabet = new ArrayList<Character>();
-    
+
     private AlphabetCallback callback;
 
     public AlphabetBar(Context context)
@@ -56,35 +56,35 @@ public class AlphabetBar extends LinearLayout
     public AlphabetBar(Context context, AttributeSet attrs)
     {
         super(context, attrs);
-        
+
         ColourProfile profile = RoboGuice.getInjector(context).getInstance(Configuration.class)
-        	.getColourProfile();
-        
+            .getColourProfile();
+
         if ( profile == ColourProfile.DAY ) {
-        	setBackgroundResource(R.drawable.alphabet_bar_bg);
+            setBackgroundResource(R.drawable.alphabet_bar_bg);
         } else {
-        	setBackgroundResource(R.drawable.alphabet_bar_bg_dark);
+            setBackgroundResource(R.drawable.alphabet_bar_bg_dark);
         }
-        
+
         init();
     }
-    
+
     public void setAlphabet(List<Character> alphabet ) {
-    	this.alphabet = alphabet;
-    	updateLabels();
-    	invalidate();
+        this.alphabet = alphabet;
+        updateLabels();
+        invalidate();
     }
-    
+
     public void setCallback(AlphabetCallback callback) {
-		this.callback = callback;
-	}
+        this.callback = callback;
+    }
 
     private void updateLabels() {
-    	
-    	removeAllViews();
-    	
-    	for ( final Character currentChar: this.alphabet ) {
-            
+
+        removeAllViews();
+
+        for ( final Character currentChar: this.alphabet ) {
+
             TextView label = new TextView(getContext());
             label.setText(String.valueOf(currentChar));
             label.setGravity(Gravity.CENTER_VERTICAL);
@@ -92,26 +92,26 @@ public class AlphabetBar extends LinearLayout
             label.setClickable(true);
             label.setFocusable(true);
             label.setOnClickListener( v ->  {
-                if ( callback != null ) {
-                    callback.characterClicked(currentChar);
-                }
-            });
+                    if ( callback != null ) {
+                        callback.characterClicked(currentChar);
+                    }
+                });
 
             addView(label, new LinearLayout.LayoutParams(
-              LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT));
+                    LayoutParams.FILL_PARENT, LayoutParams.WRAP_CONTENT));
         }
     }
-    
+
     public void init()
     {
-    	setLayoutParams(new LinearLayout.LayoutParams(
-    	          LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT));
+        setLayoutParams(new LinearLayout.LayoutParams(
+                LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT));
 
-    	        /* Not strictly necessary since we override onLayout and onMeasure with
-    	         * our custom logic, but it seems like good form to do this just to
-    	         * show how we're arranging the children. */
-    	        setOrientation(VERTICAL);        
-    }   
+        /* Not strictly necessary since we override onLayout and onMeasure with
+         * our custom logic, but it seems like good form to do this just to
+         * show how we're arranging the children. */
+        setOrientation(VERTICAL);
+    }
 
     @Override
     protected void onLayout(boolean changed, int l, int t, int r, int b)
@@ -119,11 +119,11 @@ public class AlphabetBar extends LinearLayout
         super.onLayout(changed, l, t, r, b);
     }
 
-    
+
     @Override
     protected void onMeasure(int wSpec, int hSpec)
     {
-        Log.d(TAG, "onMeasure(" + wSpec + ", " + hSpec + ")");      
+        Log.d(TAG, "onMeasure(" + wSpec + ", " + hSpec + ")");
 
         int count = getChildCount();
 
@@ -134,10 +134,10 @@ public class AlphabetBar extends LinearLayout
 
         int maxWidth = 0;
 
-        int hSizeAdj = hSize - getPaddingTop() - getPaddingBottom(); 
+        int hSizeAdj = hSize - getPaddingTop() - getPaddingBottom();
         float childHeight = 0f;
         if ( count > 0 ) {
-        	childHeight = hSizeAdj / count;
+            childHeight = hSizeAdj / count;
         }
 
         /* Calculate how many extra 1-pixel spaces we'll need in order to make
@@ -147,35 +147,34 @@ public class AlphabetBar extends LinearLayout
         int paddingWidth = getPaddingLeft() + getPaddingRight();
 
         for (int i = 0; i < count; i++)
-        {
-            TextView label = (TextView)getChildAt(i);
-
-            label.setTextSize(childHeight * 0.5F);
-
-            int thisHeight = (int)childHeight;
-
-            if (variance > 0)
             {
-                thisHeight++;
-                variance--;
+                TextView label = (TextView)getChildAt(i);
+
+                label.setTextSize(childHeight * 0.5F);
+
+                int thisHeight = (int)childHeight;
+
+                if (variance > 0)
+                    {
+                        thisHeight++;
+                        variance--;
+                    }
+
+
+                label.measure
+                    (MeasureSpec.makeMeasureSpec(26, MeasureSpec.EXACTLY),
+                        MeasureSpec.makeMeasureSpec(thisHeight, MeasureSpec.EXACTLY));
+
+
+                maxWidth = Math.max(maxWidth, label.getMeasuredWidth());
             }
-
-            
-            label.measure
-              (MeasureSpec.makeMeasureSpec(26, MeasureSpec.EXACTLY),
-               MeasureSpec.makeMeasureSpec(thisHeight, MeasureSpec.EXACTLY));		
-            
-
-            maxWidth = Math.max(maxWidth, label.getMeasuredWidth());
-        }
 
         maxWidth += paddingWidth;
 
-        setMeasuredDimension(resolveSize(maxWidth, wSpec), hSize); 
-    }   
-    
+        setMeasuredDimension(resolveSize(maxWidth, wSpec), hSize);
+    }
+
     public static interface AlphabetCallback {
-    	public void characterClicked( Character c );
+        public void characterClicked( Character c );
     }
 }
-

--- a/src/net/nightwhistler/pageturner/view/AnimatedImageView.java
+++ b/src/net/nightwhistler/pageturner/view/AnimatedImageView.java
@@ -27,26 +27,26 @@ import net.nightwhistler.pageturner.animation.Animator;
 
 public class AnimatedImageView extends ImageView {
 
-	private Animator animator;
-	
-	public AnimatedImageView(Context context, AttributeSet attributes) {
-		super(context, attributes);		
-	}
-	
-	public void setAnimator(Animator animator) {
-		this.animator = animator;
-	}
-	
-	public Animator getAnimator() {
-		return animator;
-	}
-	
-	@Override
-	protected void onDraw(Canvas canvas) {
-		super.onDraw(canvas);
-		
-		if ( this.animator != null ) {
-			animator.draw(canvas);
-		}
-	}
+    private Animator animator;
+
+    public AnimatedImageView(Context context, AttributeSet attributes) {
+        super(context, attributes);
+    }
+
+    public void setAnimator(Animator animator) {
+        this.animator = animator;
+    }
+
+    public Animator getAnimator() {
+        return animator;
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+
+        if ( this.animator != null ) {
+            animator.draw(canvas);
+        }
+    }
 }


### PR DESCRIPTION
This was done via macros but it looks OK to me at a once-over, it should
be possible to change anything that seems wrong.

Indents are 4 spaces, as requested. All tabs removed.

Multiline argument lists are indented two levels beneath the function
definition or call.

Opening braces haven't been moved to the same line as the defining
function if they weren't already there. There seem to be relatively few
of these anyhow.

For the record, the output of this is emacs' standard java-mode
indentation with the following hook set:

> ; Don't indent argument lists aggressively in Java
> (add-hook 'java-mode-hook '(lambda ()
>     (c-set-offset 'arglist-intro '+)
>          (c-set-offset 'arglist-cont-nonempty '++)
>	       ))

... which is hopefully fairly similar to what IntelliJ does.